### PR TITLE
fix: Added title text when service logo is missing

### DIFF
--- a/dcv-access-console-web-client/server/src/components/common/top-nav-bar/TopNavBar.tsx
+++ b/dcv-access-console-web-client/server/src/components/common/top-nav-bar/TopNavBar.tsx
@@ -18,7 +18,7 @@ export default function TopNavBar({session}: { session: Session }) {
         const img = new Image();
         img.onload = () => setServiceLogoExists(true);
         img.onerror = () => setServiceLogoExists(false);
-        img.src = service.nameImage.src;
+        img.src = service.nameImage;
     }, []);
 
     return (
@@ -26,9 +26,10 @@ export default function TopNavBar({session}: { session: Session }) {
             identity={{
                 href: "/sessions",
                 logo: serviceLogoExists ? {
-                    src: service.nameImage.src,
-                    alt: service.nameImage.alt
-                } : undefined
+                    src: service.nameImage,
+                    alt: service.serviceName
+                } : undefined,
+                title: serviceLogoExists ? undefined : service.serviceName
             }}
             utilities={[
                 {

--- a/dcv-access-console-web-client/server/src/constants/service-constants.ts
+++ b/dcv-access-console-web-client/server/src/constants/service-constants.ts
@@ -6,10 +6,8 @@ export const service = {
         src: '/footer-logo.svg',
         alt: 'aws-logo'
     },
-    nameImage: {
-        src: '/service-name.svg',
-        alt: 'DCV Access Console'
-    },
+    nameImage: '/service-name.svg',
+    serviceName: 'DCV Access Console',
     loginBackground: '/login-background.svg',
     tagline: 'Manage and connect to your Amazon DCV sessions.',
     osLogos: {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added a title text saying "DCV Access Console" in the scenario that the service logo is missing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
