### PR TITLE
docs: Updates EULA to version 8.5

### DIFF
--- a/dcv-access-console-auth-server/src/static-pages/public/eula.html
+++ b/dcv-access-console-auth-server/src/static-pages/public/eula.html
@@ -9,21 +9,24 @@
   <div style="white-space: pre-wrap">
   END-USER LICENSE AGREEMENT (EULA)
   for NICE Software and Solutions
-  (Version 8.3)
+  (Version 8.5)
 
   This End User License Agreement ("EULA" or "Agreement") contains the terms
   and conditions that govern your ("Licensee" or "you" or "your") access to and
-  use of NICE EnginFrame and NICE DCV (together with any updates or
-  enhancements, and accompanying documentation, "Software") and NICE DCV Web
-  Client software development kit ("SDK"). As used in this EULA, "NICE" means
-  NICE, S.r.l. with principal offices located at Via Milliavacca, 9 - 14100
-  Asti - Italy ("NICE IT"), except that if Licensee is located in the United
-  States, "NICE" means NICE USA LLC, with principal offices at 410 Terry Avenue
-  North, Seattle, Washington, 98109-5210 ("NICE US"). This EULA supplements
-  the AWS Customer Agreement posted at aws.amazon.com/agreement or other
-  agreement with NICE or an affiliate governing your use of NICE services (the
-  "Customer Agreement"), and unless otherwise defined in this EULA, capitalized
-  terms will have the same meaning as set forth in the Customer Agreement.
+  use of NICE EnginFrame and Amazon DCV (together with any updates, including
+  updates to the software name, or enhancements, and accompanying documentation,
+  "Software") and Amazon DCV Web Client software development kit (together with
+  any updates, including any updates to the software development kit name, or
+  enhancements, and accompanying documentation,"SDK"). As used in this EULA,
+  "NICE" means NICE, S.r.l. with principal offices located at Via Milliavacca,
+  9 – 14100 Asti - Italy ("NICE IT"), except that if Licensee is located in the
+  United States, "NICE" means NICE USA LLC, with principal offices at 410 Terry
+  Avenue North, Seattle, Washington, 98109-5210 ("NICE US"). This EULA
+  supplements the AWS Customer Agreement posted at aws.amazon.com/agreement
+  or other agreement with NICE or an affiliate governing your use of NICE
+  services (the "Customer Agreement"), and unless otherwise defined in this
+  EULA, capitalized terms will have the same meaning as set forth in the
+  Customer Agreement.
 
   1. LICENSE TO AND USE OF THE SOFTWARE. The Software may be accessed and used
   only in accordance with this EULA and the Customer Agreement, and subject to
@@ -38,6 +41,19 @@
   non-sublicensable license to install and use the Software for your internal
   evaluation and testing purposes only, and only in the quantity that you have
   requested from NICE.
+  (c) The source code for the Amazon DCV Access Console Web Client, Amazon DCV
+  Access Console Handler, Amazon DCV Access Console Authentication Server,
+  Amazon DCV Access Console Configuration Wizard, Amazon DCV Access Console
+  Model, and Amazon DCV Access Console Integration Tests (“Open-Sourced Amazon
+  DCV Access Console Components”) is governed by the <a href="https://github.com/aws/dcv-access-console/blob/main/LICENSE">Apache 2.0 License</a>, not
+  this EULA or the Customer Agreement. Your access to and use of the code is
+  subject to the terms of the Apache 2.0 License. Notwithstanding the foregoing,
+  your use of Amazon DCV (including any Amazon DCV product or component
+  available for download at https://www.amazondcv.com/ and any successor or
+  related site designated by NICE) is always subject to the terms of this EULA
+  and the Customer Agreement even when they are used in combination with the
+  Open-Sourced Amazon DCV Access Console Components, or any derivative works
+  created using the Open-Sourced Amazon DCV Access Console Components.
 
   2. BETA PARTICIPATION. NICE may provide Licensee certain features,
   technologies, software, and services that are not yet generally available,
@@ -85,7 +101,7 @@
   (a) Licensee will not distribute, rent, lease, lend, loan, transfer, assign,
   resell, sublicense, disclose, or otherwise provide the Software to or use the
   Software for the benefit of any third party (including acting as a service
-  bureau or provide of a time sharing service). Notwithstanding the foregoing,
+  bureau or provider of a time sharing service). Notwithstanding the foregoing,
   Licensee may permit its third party contractors to use the software for
   Licensee's internal business purposes provided that Licensee enters to a
   binding agreement with contractor requiring contractor to comply with this
@@ -144,7 +160,7 @@
   6. SUPPORT SERVICES. Licensee may be eligible to subscribe to software
   support for any or all of the Software (the "Support Services", as described
   and regulated under the Standard Support Services for NICE Products terms,
-  available here
+  available here:
   https://www.nice-software.com/html/pdf/NICE_Standard_Support_Services.pdf, as
   may be updated). Support Services are subject to and governed by the terms of
   this EULA and the Customer Agreement, as is any update or upgrade to the
@@ -230,13 +246,13 @@
 
   10. SDK. If you downloaded the SDK, you may use, reproduce, distribute,
   publish, and sublicense the SDK, and create derivative works of the SDK and
-  NICE DCV Web Client solely to the extent those derivative works implement the
-  NICE DCV Web Client, subject to the following conditions:
+  Amazon DCV Web Client solely to the extent those derivative works implement the
+  Amazon DCV Web Client, subject to the following conditions:
   (a) You will not remove any proprietary notices or labels on the SDK or any
   copy thereof.
   (b) You will include this permission notice in all copies or substantial
   portions of the SDK.
-  (c) You require that each end user before accessing the SDK, NICE DCV Web
+  (c) You require that each end user before accessing the SDK, Amazon DCV Web
   Client, or any copies, derivative works or substantial portions thereof,
   agrees to comply with this EULA.
   (d) Some components of the SDK may be governed by third party software


### PR DESCRIPTION
**Description of changes:**
* Updates EULA to version 8.5
* Links to Apache 2.0 License in EULA

**How was this change tested:**
- `./gradlew bootRun`
- Opened localhost:9000/eula.html to check EULA and link working

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
