### PR TITLE
fix: Add build variables

### DIFF
--- a/dcv-access-console-web-client/server/.env
+++ b/dcv-access-console-web-client/server/.env
@@ -1,0 +1,6 @@
+#NEXT_PUBLIC_ Prefixed variables need to be set during build time. They cannot be changed during runtime
+#https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables#bundling-environment-variables-for-the-browser
+NEXT_PUBLIC_SM_UI_AUTH_ID="dcv-access-console-auth-server"
+NEXT_PUBLIC_DEFAULT_PATH="/sessions"
+NEXT_PUBLIC_ENABLE_MOCK_WORKER="false"
+NEXT_PUBLIC_FLASH_BAR_UPDATE_IN_SECONDS=5


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adds the variables needed for build time

**Why is this change necessary:**

Without these variables the nextjs auth isn't able to find the providers and it keeps looping while it tries to connect to the auth server
This works in dev because they are set in .env.development file

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.

**Any additional information or context required to review the change:**


**Documentation Checklist:**
 - [ ] Updated the README if applicable.
 - [ ] Updated the THIRD-PARTY-LICENSES file if applicable.

**Compatibility Checklist:**
- [ X ] I confirm that the change is backwards compatible.
- [ X ] There is no modification of dependencies or if there is, a corresponding update to THIRD-PARTY-LICENSES is part of the commit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.