### PR TITLE
feat: Use loginUsername for requests to the broker

### DIFF
--- a/dcv-access-console-handler/src/main/java/handler/authorization/engines/AbstractAuthorizationEngine.java
+++ b/dcv-access-console-handler/src/main/java/handler/authorization/engines/AbstractAuthorizationEngine.java
@@ -229,6 +229,13 @@ public abstract class AbstractAuthorizationEngine {
     public abstract String getUserDisplayName(String userUUID);
 
     /**
+     * Provides the login username of the user.
+     * @param userUUID The unique identifier of the user
+     * @return Returns a String of the login username of the user
+     */
+    public abstract String getUserLoginUsername(String userUUID);
+
+    /**
      * Provides principals the resource is shared to
      * @param resourceType A String representing the type of resource, e.g. 'Session'.
      * @param resourceUUID The unique identifier of the resource to change the share list of.

--- a/dcv-access-console-handler/src/main/java/handler/authorization/engines/CedarAuthorizationEngine.java
+++ b/dcv-access-console-handler/src/main/java/handler/authorization/engines/CedarAuthorizationEngine.java
@@ -621,6 +621,12 @@ public class CedarAuthorizationEngine extends AbstractAuthorizationEngine {
     }
 
     @Override
+    public String getUserLoginUsername(String userUUID) {
+        Entity userEntity = getUserEntity(userUUID);
+        return ((EntityUID) userEntity.attrs.get(LOGINUSER_ATTRIBUTE)).getId().toString();
+    }
+
+    @Override
     public String getUserDisplayName(String userUUID) {
         Entity userEntity = getUserEntity(userUUID);
         return userEntity.attrs.get(DISPLAY_NAME_ATTRIBUTE).toString();

--- a/dcv-access-console-handler/src/main/java/handler/controllers/DescribeSessionsController.java
+++ b/dcv-access-console-handler/src/main/java/handler/controllers/DescribeSessionsController.java
@@ -114,7 +114,7 @@ public class DescribeSessionsController implements DescribeSessionsApi {
                 log.warn("User {} not authorized to view session {}", username, session.getId());
             } else {
                 log.info("User {} is authorized to view session {}", username, session.getId());
-                session.levelOfAccess(session.getOwner().equals(username) ? "Owner" : "Admin");
+                session.levelOfAccess(session.getOwner().equals(authorizationEngine.getUserLoginUsername(username)) ? "Owner" : "Admin");
                 authorizedSessions.add(session);
             }
         }

--- a/dcv-access-console-handler/src/main/java/handler/controllers/GetSessionConnectionDataController.java
+++ b/dcv-access-console-handler/src/main/java/handler/controllers/GetSessionConnectionDataController.java
@@ -73,7 +73,7 @@ public class GetSessionConnectionDataController implements GetSessionConnectionD
             log.info("Received getSessionConnectionData for sessionId: {}", sessionId);
             String username = SecurityContextHolder.getContext().getAuthentication().getName();
 
-            if (StringUtils.isNotBlank(user) && !user.equals(username)) {
+            if (StringUtils.isNotBlank(user) && !user.equals(authorizationEngine.getUserLoginUsername(username))) {
                 // Owner is not empty, and is not the current user
                 if (!authorizationEngine.isAuthorized(PrincipalType.User, username, SystemAction.getSessionConnectionDataForOther)) {
                     String message = String.format("User %s is not authorized to connect to other users sessions.", username);
@@ -89,7 +89,7 @@ public class GetSessionConnectionDataController implements GetSessionConnectionD
                         new AuthorizationServiceException(message), sessionId, UNAUTHORIZED_TO_CONNECT_TO_SESSION);
             }
 
-            GetSessionConnectionDataUIResponse response = brokerClient.getSessionConnectionData(sessionId, Optional.ofNullable(user).orElse(username));
+            GetSessionConnectionDataUIResponse response = brokerClient.getSessionConnectionData(sessionId, Optional.ofNullable(user).orElse(authorizationEngine.getUserLoginUsername(username)));
             Server server = response.getSession().getServer();
             String hostName = getHostName(server);
             String port = getPort(server);

--- a/dcv-access-console-handler/src/test/java/handler/controllers/DescribeSessionsControllerTest.java
+++ b/dcv-access-console-handler/src/test/java/handler/controllers/DescribeSessionsControllerTest.java
@@ -101,6 +101,7 @@ class DescribeSessionsControllerTest extends BaseControllerTest  {
         when(mockAuthorizationEngine.getUserRole(testUser)).thenReturn("User");
         when(mockAuthorizationEngine.isAuthorized(PrincipalType.User, testUser, ResourceAction.viewSessionDetails, ResourceType.Session, "fail")).thenReturn(false);
         when(mockAuthorizationEngine.isAuthorized(PrincipalType.User, testUser, ResourceAction.viewSessionDetails, ResourceType.Session, testId)).thenReturn(true);
+        when(mockAuthorizationEngine.getUserLoginUsername(testUser)).thenReturn(testUser);
         mvc.perform(
                         post(urlTemplate)
                                 .contentType(MediaType.APPLICATION_JSON)

--- a/dcv-access-console-web-client/server/src/components/servers/os-label/OsLabel.tsx
+++ b/dcv-access-console-web-client/server/src/components/servers/os-label/OsLabel.tsx
@@ -7,11 +7,14 @@ import {service} from "@/constants/service-constants";
 import {capitalizeFirstLetter} from "@/components/common/utils/TextUtils";
 import {SpaceBetween, TextContent} from "@cloudscape-design/components";
 import {SERVERS_TABLE_CONSTANTS} from "@/constants/servers-table-constants";
+import {useEffect, useState} from "react";
 
 export type OsLabelProps = {
     os: Os | undefined,
 }
 export default function OsLabel(props: OsLabelProps) {
+    const [osLogoExists, setOsLogoExists] = useState(false);
+
     let imgSrc
     if(!props.os) {
         return <TextContent>{SERVERS_TABLE_CONSTANTS.UNKNOWN}</TextContent>
@@ -24,8 +27,16 @@ export default function OsLabel(props: OsLabelProps) {
             imgSrc = service.osLogos.linux
             break;
     }
+
+    useEffect(() => {
+        const img = new Image();
+        img.onload = () => setOsLogoExists(true);
+        img.onerror = () => setOsLogoExists(false);
+        img.src = imgSrc;
+    }, []);
+
     return <SpaceBetween size={"xxs"} direction={"horizontal"} alignItems={"center"}>
-            <img src={imgSrc} alt={props.os?.Family}/>
+        {osLogoExists ? <img src={imgSrc} alt={props.osFamily}/> : undefined}
             <TextContent>
                 {capitalizeFirstLetter(props.os?.Family?.toString())}
             </TextContent>

--- a/dcv-access-console-web-client/server/src/context-providers/FlashBarContext.tsx
+++ b/dcv-access-console-web-client/server/src/context-providers/FlashBarContext.tsx
@@ -160,7 +160,7 @@ export const FlashBarContextProvider = ({children}) => {
                 type: "error",
                 loading: false,
                 content: <>
-                        Unable to create session "{sessionName}" due to: {reason}.
+                        Unable to create session "{sessionName}" due to: {reason}
                         <br/>
                         Please contact your administrator.
                     </>,


### PR DESCRIPTION
**Description of changes:**
Updated the controllers that describe, create, and launch sessions to use loginUsername instead of the default username from access console. This is a follow-up to the [PR](https://github.com/aws/dcv-access-console/pull/30) which includes all the auth engine and service changes.

**Why is this change necessary:**
loginUsername is required by the broker to work correctly with the requests sent by the handler.

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.
 - [ ] Updated the THIRD-PARTY-LICENSES file if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [x] There is no modification of dependencies or if there is, a corresponding update to THIRD-PARTY-LICENSES is part of the commit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
