### PR TITLE
feat: Adds claim retrieval from access token for MS Entra integration

### DIFF
--- a/dcv-access-console-handler/README.md
+++ b/dcv-access-console-handler/README.md
@@ -21,6 +21,9 @@ The following properties can help with this:
 * `auth-server-well-known-uri` is the well known URI (required only if userInfo endpoint is not provided)
 * `auth-server-userinfo-endpoint` is the userInfo endpoint
 
+When using MS Entra as an OAuth provider, the access token cannot be used to query the userInfo endpoint. In this case, claims can be read from the access token:
+* `auth-server-claims-from-access-token` determines whether to read claims directly from the access token instead of calling the userInfo endpoint. To enable set to true. Default is false.
+
 ## Testing
 While running the application you can use Postman to send requests to the endpoints to ensure correct functionality.
 

--- a/dcv-access-console-handler/src/main/java/handler/controllers/DescribeUserInfoController.java
+++ b/dcv-access-console-handler/src/main/java/handler/controllers/DescribeUserInfoController.java
@@ -39,6 +39,9 @@ public class DescribeUserInfoController implements DescribeUserInfoApi {
     @Value("${jwt-display-name-claim-key:#{null}}")
     private String displayNameKey;
 
+    @Value("${auth-server-claims-from-access-token:false}")
+    private boolean useAuthServerClaimsFromAccessToken;
+
     @Override
     public ResponseEntity<DescribeUserInfoResponse> describeUserInfo() {
         try {
@@ -67,11 +70,17 @@ public class DescribeUserInfoController implements DescribeUserInfoApi {
     }
 
     private void updateUserFromAuthServer(String username) {
-        String accessToken = ((JwtAuthenticationToken) SecurityContextHolder.getContext()
-                .getAuthentication()).getToken().getTokenValue();
+        Map<String, Object> userInfo = null;
 
-        Map<String, Object> userInfo = authServerClientService.getUserInfo(accessToken);
+        if (useAuthServerClaimsFromAccessToken) {
+            userInfo = ((JwtAuthenticationToken) SecurityContextHolder.getContext()
+                    .getAuthentication()).getToken().getClaims();
+        } else {
+            String accessToken = ((JwtAuthenticationToken) SecurityContextHolder.getContext()
+                    .getAuthentication()).getToken().getTokenValue();
 
+            userInfo = authServerClientService.getUserInfo(accessToken);
+        }
         if (userInfo == null) {
             return;
         }

--- a/dcv-access-console-handler/src/main/resources/access-console-handler.properties
+++ b/dcv-access-console-handler/src/main/resources/access-console-handler.properties
@@ -36,6 +36,7 @@ jwt-login-username-claim-key =
 jwt-display-name-claim-key =
 auth-server-well-known-uri =
 auth-server-userinfo-endpoint =
+auth-server-claims-from-access-token = false
 
 # Authorization
 user-id-case-sensitive = true

--- a/dcv-access-console-web-client/README.md
+++ b/dcv-access-console-web-client/README.md
@@ -50,15 +50,16 @@ npm run test
 Ensure that the auth-server is running and set the following variables in `.env.development`:
 1. SM_UI_HANDLER_BASE_URL - Change the `<replace>` to the URL of the Handler, with the port
 2. SM_UI_AUTH_WELL_KNOWN_URI  - Change the `<replace>` to the URL of the Auth Server, with the port
-3. SM_UI_AUTH_CLIENT_ID - Should match the `client-id` of the Auth Server
-4. SM_UI_AUTH_CLIENT_SECRET - Should match `client-secret` of the Auth Server, without `{noop}`
-5. SM_UI_AUTH_ENABLE_PROVIDER_LOGOUT - Set as true (default) if the sign out event should log out from the auth provider as well (useful when using external providers)
-6. SM_UI_AUTH_LOGOUT_URI - Set as the logout endpoint when using an external auth provider, empty (default) will look for `end_session_endpoint` from the well_known json
-7. NEXT_PUBLIC_SM_UI_AUTH_ID - Should match the ending of `redirect-uris` in the Auth Server `access-console-auth-server.properties` file
-8. NEXT_PUBLIC_DEFAULT_PATH - Leave as `/sessions`
-9. NEXTAUTH_SECRET - Set a string 
-10. NODE_EXTRA_CA_CERTS - Path to cert file 
-11. SESSION_SCREENSHOT_MAX_WIDTH and SESSION_SCREENSHOT_MAX_HEIGHT - Can be undefined or a value greater than or equal to 0. If set to 0, the resolution set in the Broker configuration will be used. If undefined, default values will be used.
+3. SM_UI_AUTH_SERVER_SCOPE - When using an external auth provider, the custom scope can be set. The default is "openid". Multiple scopes can be specified by separating them with spaces.
+4. SM_UI_AUTH_CLIENT_ID - Should match the `client-id` of the Auth Server
+5. SM_UI_AUTH_CLIENT_SECRET - Should match `client-secret` of the Auth Server, without `{noop}`
+6. SM_UI_AUTH_ENABLE_PROVIDER_LOGOUT - Set as true (default) if the sign out event should log out from the auth provider as well (useful when using external providers)
+7. SM_UI_AUTH_LOGOUT_URI - Set as the logout endpoint when using an external auth provider, empty (default) will look for `end_session_endpoint` from the well_known json
+8. NEXT_PUBLIC_SM_UI_AUTH_ID - Should match the ending of `redirect-uris` in the Auth Server `access-console-auth-server.properties` file
+9. NEXT_PUBLIC_DEFAULT_PATH - Leave as `/sessions`
+10. NEXTAUTH_SECRET - Set a string 
+11. NODE_EXTRA_CA_CERTS - Path to cert file 
+12. SESSION_SCREENSHOT_MAX_WIDTH and SESSION_SCREENSHOT_MAX_HEIGHT - Can be undefined or a value greater than or equal to 0. If set to 0, the resolution set in the Broker configuration will be used. If undefined, default values will be used.
 
 ## Running the development server
 ```bash

--- a/dcv-access-console-web-client/server/.env.development
+++ b/dcv-access-console-web-client/server/.env.development
@@ -1,6 +1,7 @@
 SM_UI_HANDLER_BASE_URL="http://<replace>:8080"
 SM_UI_HANDLER_API_PREFIX="/smuihandler"
 SM_UI_AUTH_WELL_KNOWN_URI="http://<replace>:9000/.well-known/oauth-authorization-server"
+SM_UI_AUTH_SERVER_SCOPE="openid"
 SM_UI_AUTH_CLIENT_ID="dcv-sm-ui-webclient"
 SM_UI_AUTH_CLIENT_SECRET="replace"
 SM_UI_AUTH_ENABLE_PROVIDER_LOGOUT="true"

--- a/dcv-access-console-web-client/server/access-console-web-client.properties
+++ b/dcv-access-console-web-client/server/access-console-web-client.properties
@@ -5,3 +5,4 @@ web-client-url = "http://webclient-host:webclient-port"
 #extra-ca-certs = "<PATH-TO-CERT>/rootCA.pem"
 session-screenshot-max-width = 1280
 session-screenshot-max-height = 960
+auth-server-scope = "openid"

--- a/dcv-access-console-web-client/server/run-server
+++ b/dcv-access-console-web-client/server/run-server
@@ -12,6 +12,7 @@ cat /etc/dcv-access-console-web-client/access-console-web-client-*.properties >>
 sed -Ei "s/handler-base-url/SM_UI_HANDLER_BASE_URL/g" ./.env
 sed -Ei "s/handler-api-prefix/SM_UI_HANDLER_API_PREFIX/g" ./.env
 sed -Ei "s/auth-server-well-known-uri/SM_UI_AUTH_WELL_KNOWN_URI/g" ./.env
+sed -Ei "s/auth-server-scope/SM_UI_AUTH_SERVER_SCOPE/g" ./.env
 sed -Ei "s/auth-server-client-id/SM_UI_AUTH_CLIENT_ID/g" ./.env
 sed -Ei "s/auth-server-client-secret/SM_UI_AUTH_CLIENT_SECRET/g" ./.env
 sed -Ei "s/web-client-url/NEXTAUTH_URL/g" ./.env

--- a/dcv-access-console-web-client/server/src/app/api/auth/[...nextauth]/route.tsx
+++ b/dcv-access-console-web-client/server/src/app/api/auth/[...nextauth]/route.tsx
@@ -121,7 +121,7 @@ export const authOptions: NextAuthOptions = {
         wellKnown: process.env.SM_UI_AUTH_WELL_KNOWN_URI,
         clientId: process.env.SM_UI_AUTH_CLIENT_ID,
         clientSecret: process.env.SM_UI_AUTH_CLIENT_SECRET,
-        authorization: {params: {scope: "openid"}},
+        authorization: {params: {scope: process.env.SM_UI_AUTH_SERVER_SCOPE}},
         checks: ["nonce", "pkce", "state"],
         idToken: true,
         userinfo: {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
* Adds parameter `auth-server-claims-from-access-token` to Handler to determine if userInfo endpoint call should be bypassed and claims should be extracted from the access token instead for MS Entra integration. 
* Adds parameter `SM_UI_AUTH_SERVER_SCOPE` to set custom scope for MS Entra integration.

**Why is this change necessary:**
* This change is necessary so MS Entra can be used as an OAuth provider. 

**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [x] Updated the README if applicable.
 - [ ] Updated the THIRD-PARTY-LICENSES file if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [x] There is no modification of dependencies or if there is, a corresponding update to THIRD-PARTY-LICENSES is part of the commit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
