### PR TITLE
feat: Add auth server claim properties to config wizard for MS Entra …

### DIFF
--- a/dcv-access-console-configuration-wizard/src/dcv_access_console_config_wizard/assets/default_configs/access-console-handler.properties
+++ b/dcv-access-console-configuration-wizard/src/dcv_access_console_config_wizard/assets/default_configs/access-console-handler.properties
@@ -36,6 +36,7 @@ jwt-login-username-claim-key =
 jwt-display-name-claim-key =
 auth-server-well-known-uri =
 auth-server-userinfo-endpoint =
+auth-server-claims-from-access-token = false
 
 # Authorization
 user-id-case-sensitive = true

--- a/dcv-access-console-configuration-wizard/src/dcv_access_console_config_wizard/assets/default_configs/access-console-web-client.properties
+++ b/dcv-access-console-configuration-wizard/src/dcv_access_console_config_wizard/assets/default_configs/access-console-web-client.properties
@@ -5,3 +5,4 @@ web-client-url = "http://webclient-host:webclient-port"
 #extra-ca-certs = "<PATH-TO-CERT>/rootCA.pem"
 session-screenshot-max-width = 1280
 session-screenshot-max-height = 960
+auth-server-scope = "openid"

--- a/dcv-access-console-configuration-wizard/src/dcv_access_console_config_wizard/cli.py
+++ b/dcv-access-console-configuration-wizard/src/dcv_access_console_config_wizard/cli.py
@@ -1124,6 +1124,22 @@ def exit_with_failure_message(tasks_completed, failed_task):
     prompt=None,
 )
 @click.option(
+    "--claims-from-access-token",
+    default=False,
+    help="Determines whether to read claims directly from the access token instead of calling the userInfo endpoint. "
+    "To enable set to true. Default is false.",
+    required=False,
+    prompt=None,
+)
+@click.option(
+    "--auth-server-scope",
+    default="openid",
+    help="When using an external auth provider, the custom scope can be set. Multiple scopes can be specified by "
+    "separating them with spaces.",
+    required=False,
+    prompt=None,
+)
+@click.option(
     "--install-nginx/--no-install-nginx",
     is_flag=True,
     help="Installs NGINX on this machine",
@@ -1250,6 +1266,7 @@ def run(
     webclient_cert_path,
     webclient_cert_key_path,
     root_ca_path,
+    auth_server_scope,
     use_pam_authentication,
     pam_service_name,
     normalize_userid,
@@ -1267,6 +1284,7 @@ def run(
     display_name_claim_key,
     well_known_uri,
     userinfo_endpoint,
+    claims_from_access_token,
     install_nginx,
     install_components,
     component_installers_location,
@@ -1530,6 +1548,7 @@ def run(
             webclient_cert_path=webclient_cert_path,
             webclient_key_path=webclient_cert_key_path,
             root_ca_path=root_ca_path,
+            auth_server_scope=auth_server_scope,
             handler_keystore_path=handler_keystore_path,
             handler_keystore_password=handler_keystore_password,
             auth_server_keystore_path=auth_server_keystore_path,
@@ -1550,6 +1569,7 @@ def run(
             display_name_claim_key=display_name_claim_key,
             well_known_uri=well_known_uri,
             userinfo_endpoint=userinfo_endpoint,
+            claims_from_access_token=claims_from_access_token,
             read_existing_configs=read_existing_configs,
             save_location=configuration_file_save_location,
         ):

--- a/dcv-access-console-configuration-wizard/src/dcv_access_console_config_wizard/conf/configuration_generator.py
+++ b/dcv-access-console-configuration-wizard/src/dcv_access_console_config_wizard/conf/configuration_generator.py
@@ -189,6 +189,7 @@ def modify_handler_config(
     display_name_claim_key: str,
     well_known_uri: str,
     userinfo_endpoint: str,
+    claims_from_access_token: bool,
 ) -> Any:
     dynamodb_lines = {
         "dynamodb-region": dynamodb_region,
@@ -211,6 +212,7 @@ def modify_handler_config(
         "jwt-display-name-claim-key": f"{display_name_claim_key}",
         "auth-server-well-known-uri": f"{well_known_uri}",
         "auth-server-userinfo-endpoint": f"{userinfo_endpoint}",
+        "auth-server-claims-from-access-token": str(claims_from_access_token).lower(),
         "enable-connection-gateway": str(enable_connection_gateway).lower(),
         "connection-gateway-host": connection_gateway_host or "gatewayhostname",
         "connection-gateway-port": connection_gateway_port,
@@ -282,6 +284,7 @@ def modify_webclient_config(
     handler_address: str,
     handler_prefix: str,
     root_ca_path: Path,
+    auth_server_scope: str,
 ) -> Any:
 
     replacement_lines = {
@@ -290,6 +293,7 @@ def modify_webclient_config(
         "auth-server-well-known-uri": f"{authserver_address}/.well-known/oauth-authorization-server",
         "web-client-url": webclient_address,
         "extra-ca-certs": f"{root_ca_path}",
+        "auth-server-scope": f"{auth_server_scope}",
     }
 
     for line in data:
@@ -504,6 +508,7 @@ def create_configuration_files(
     webclient_cert_path: Path,
     webclient_key_path: Path,
     root_ca_path: Path,
+    auth_server_scope: str,
     handler_keystore_path: Path,
     handler_keystore_password: str,
     auth_server_keystore_path: Path,
@@ -524,6 +529,7 @@ def create_configuration_files(
     display_name_claim_key: str,
     well_known_uri: str,
     userinfo_endpoint: str,
+    claims_from_access_token: bool,
     read_existing_configs: bool,
     save_location: Path = None,
 ) -> bool:
@@ -652,6 +658,7 @@ def create_configuration_files(
         display_name_claim_key=display_name_claim_key,
         well_known_uri=well_known_uri,
         userinfo_endpoint=userinfo_endpoint,
+        claims_from_access_token=claims_from_access_token,
     )
 
     write_lines_to_file(
@@ -721,6 +728,7 @@ def create_configuration_files(
         handler_address=handler_address,
         handler_prefix=handler_prefix,
         root_ca_path=root_ca_path,
+        auth_server_scope=auth_server_scope,
     )
 
     write_lines_to_file(

--- a/dcv-access-console-configuration-wizard/test/conf/test_configuration.py
+++ b/dcv-access-console-configuration-wizard/test/conf/test_configuration.py
@@ -8,7 +8,7 @@ from dcv_access_console_config_wizard.conf.configuration_generator import modify
 
 class ConfigurationTest(TestCase):
     def test_modify_webclient_config(self):
-        modify_webclient_config([], "lorem", "ipsum", "dolor", "sit", "amet")
+        modify_webclient_config([], "lorem", "ipsum", "dolor", "sit", "amet", "consectetur")
         self.assertTrue(True)
 
 


### PR DESCRIPTION
…integration

**Issue #, if available:**

**Description of changes:**
 Added the handler and webclient properties for extracting claims from through the access token to the config wizard for MS Entra integration

**Why is this change necessary:**
 Allow specifying those properties using the config wizard

**How was this change tested:**
1. `python3 wizard.py --auth-server-scope "openid email"`

Resulting `access-console-web-client.properties`
```
handler-base-url=https://example.com
handler-api-prefix=/accessconsolehandler
auth-server-well-known-uri=https://example.com/.well-known/oauth-authorization-server
web-client-url=https://example.com
extra-ca-certs=/usr/local/var/dcv-access-console/security/rootCA.pem
session-screenshot-max-width = 1280
session-screenshot-max-height = 960
auth-server-scope=openid email
```
2. `python3 wizard.py --claims-from-access-token true`
Resulting `access-console-handler.properties`
```
jwt-login-username-claim-key=
jwt-display-name-claim-key=
auth-server-well-known-uri=
auth-server-userinfo-endpoint=
auth-server-claims-from-access-token=true
```


- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.
 - [ ] Updated the THIRD-PARTY-LICENSES file if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [x] There is no modification of dependencies or if there is, a corresponding update to THIRD-PARTY-LICENSES is part of the commit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
