### PR TITLE
Wip/ustraria/msentrafix

### DIFF
--- a/dcv-access-console-configuration-wizard/src/dcv_access_console_config_wizard/conf/configuration_generator.py
+++ b/dcv-access-console-configuration-wizard/src/dcv_access_console_config_wizard/conf/configuration_generator.py
@@ -359,6 +359,10 @@ def modify_nginx_config(
     ssl_ciphers HIGH:!aNULL:!MD5;
     ssl_prefer_server_ciphers on;
 
+    proxy_buffer_size 16k;
+    proxy_buffers 4 16k;
+    proxy_busy_buffers_size 32k;
+
     location @access_console_webclient {{
         proxy_pass  http://127.0.0.1:{webclient_port}$uri;
         proxy_intercept_errors on;

--- a/dcv-access-console-web-client/server/src/app/api/auth/[...nextauth]/route.tsx
+++ b/dcv-access-console-web-client/server/src/app/api/auth/[...nextauth]/route.tsx
@@ -169,7 +169,7 @@ export const authOptions: NextAuthOptions = {
             }
 
             // Return previous token if the access token has not expired yet
-            if (token.access_token_expires_at && Date.now() < token.access_token_expires_at) {
+            if (token.access_token_expires_at && Date.now() < token.access_token_expires_at * 1000) {
                 return token
             }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
* Adds parameters for buffer size for large headers
* Reverts logging for debugging
* Converts `token.access_token_expires_at` from seconds to milliseconds to be comparable to Date.now() which is in milliseconds

**Why is this change necessary:**
* Buffer needed to support large headers with multiple scopes

**How was this change tested:**
* Salvo added the buffer parameters to configuration file and confirmed error was gone
* Salvo tested with his MS Entra set up
* `python3 wizard.py` and confirmed new buffer parameters in the configuration output
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.
 - [ ] Updated the THIRD-PARTY-LICENSES file if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [x] There is no modification of dependencies or if there is, a corresponding update to THIRD-PARTY-LICENSES is part of the commit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
