### PR TITLE
feat: Adds support for filtering and sorting by loginUsername with us…

### DIFF
--- a/dcv-access-console-handler/src/main/java/handler/controllers/DescribeSessionTemplatesController.java
+++ b/dcv-access-console-handler/src/main/java/handler/controllers/DescribeSessionTemplatesController.java
@@ -13,19 +13,21 @@ import handler.errors.HandlerErrorMessage;
 import handler.exceptions.BadRequestException;
 import handler.model.DescribeSessionTemplatesRequestData;
 import handler.model.DescribeSessionTemplatesResponse;
+import handler.model.DescribeUsersRequestData;
 import handler.model.Error;
 import handler.model.FilterToken;
 import handler.model.FilterTokenStrict;
 import handler.model.SessionTemplate;
+import handler.model.User;
 import handler.services.SessionTemplateService;
+import handler.services.UserService;
 import handler.utils.Filter;
 import handler.utils.NextToken;
 import handler.utils.Sort;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.eclipse.jetty.util.StringUtil;
-import org.mariadb.jdbc.util.StringUtils;
+import org.springframework.util.CollectionUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -34,9 +36,11 @@ import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.Set;
 
 import static handler.errors.CommonErrorsEnum.BAD_REQUEST_ERROR;
 import static handler.errors.DescribeSessionTemplatesErrors.DESCRIBE_SESSION_TEMPLATES_DEFAULT_MESSAGE;
@@ -46,6 +50,7 @@ import static handler.errors.DescribeSessionTemplatesErrors.DESCRIBE_SESSION_TEM
 @RequiredArgsConstructor
 public class DescribeSessionTemplatesController implements DescribeSessionTemplatesApi {
     private final SessionTemplateService sessionTemplateService;
+    private final UserService userService;
     private final Filter<DescribeSessionTemplatesRequestData, SessionTemplate> sessionTemplateFilter;
     private final Sort<DescribeSessionTemplatesRequestData, SessionTemplate> sessionTemplateSort;
     private final AbstractAuthorizationEngine authorizationEngine;
@@ -66,6 +71,8 @@ public class DescribeSessionTemplatesController implements DescribeSessionTempla
             DescribeSessionTemplatesRequestData request) {
         try {
             log.info("Received describeSessionTemplates request: {}", request);
+
+            LoginUsernameResolution resolution = resolveLoginUsernameFilters(request);
 
             String username = SecurityContextHolder.getContext().getAuthentication().getName();
 
@@ -88,6 +95,8 @@ public class DescribeSessionTemplatesController implements DescribeSessionTempla
                         log.warn("User {} is not authorized to perform describeSessionTemplates for others", username);
                     }
                 }
+
+                filteredSessionTemplates = preFilterExclusions(filteredSessionTemplates, resolution);
 
                 filteredSessionTemplates = sessionTemplateFilter.getFiltered(request, filteredSessionTemplates);
 
@@ -136,5 +145,95 @@ public class DescribeSessionTemplatesController implements DescribeSessionTempla
             }
         }
         return authorizedSessionTemplates;
+    }
+
+    private record LoginUsernameResolution(
+        Set<String> excludedCreatedByUserIds,
+        Set<String> excludedLastModifiedByUserIds
+    ) {}
+
+    private List<SessionTemplate> preFilterExclusions(List<SessionTemplate> templates, LoginUsernameResolution resolution) {
+        return templates.stream()
+            .filter(t -> !resolution.excludedCreatedByUserIds.contains(t.getCreatedBy()))
+            .filter(t -> !resolution.excludedLastModifiedByUserIds.contains(t.getLastModifiedBy()))
+            .toList();
+    }
+
+    private LoginUsernameResolution resolveLoginUsernameFilters(DescribeSessionTemplatesRequestData request) {
+        Set<String> excludedCreatedBy = new HashSet<>();
+        Set<String> excludedLastModifiedBy = new HashSet<>();
+
+        if (!CollectionUtils.isEmpty(request.getCreatedByLoginUsername())) {
+            ResolvedFilters resolved = resolveLoginUsernameFiltersToUserIdFilters(request.getCreatedByLoginUsername());
+            request.setCreatedBy(resolved.filters);
+            excludedCreatedBy.addAll(resolved.excludedUserIds);
+        }
+
+        if (!CollectionUtils.isEmpty(request.getLastModifiedByLoginUsername())) {
+            ResolvedFilters resolved = resolveLoginUsernameFiltersToUserIdFilters(request.getLastModifiedByLoginUsername());
+            request.setLastModifiedBy(resolved.filters);
+            excludedLastModifiedBy.addAll(resolved.excludedUserIds);
+        }
+
+        if (!CollectionUtils.isEmpty(request.getUsersSharedWithLoginUsername())) {
+            request.setUsersSharedWith(resolveLoginUsernameFiltersForUsersSharedWith(request.getUsersSharedWithLoginUsername()));
+        }
+
+        return new LoginUsernameResolution(excludedCreatedBy, excludedLastModifiedBy);
+    }
+
+    private List<FilterTokenStrict> resolveLoginUsernameFiltersForUsersSharedWith(List<FilterToken> loginUsernameFilters) {
+        List<FilterTokenStrict> result = new ArrayList<>();
+        for (FilterToken filter : loginUsernameFilters) {
+            DescribeUsersRequestData userRequest = new DescribeUsersRequestData();
+            userRequest.setLoginUsernames(List.of(new FilterToken().operator(FilterToken.OperatorEnum.EQUAL).value(filter.getValue())));
+            List<User> users = userService.describeUsers(userRequest).getUsers();
+
+            if (users.isEmpty()) {
+                result.add(new FilterTokenStrict()
+                    .operator(FilterTokenStrict.OperatorEnum.fromValue(filter.getOperator().getValue()))
+                    .value(filter.getValue()));
+            } else {
+                FilterTokenStrict.OperatorEnum resultOp = filter.getOperator() == FilterToken.OperatorEnum.NOT_EQUAL
+                    ? FilterTokenStrict.OperatorEnum.NOT_EQUAL
+                    : FilterTokenStrict.OperatorEnum.EQUAL;
+                for (User user : users) {
+                    result.add(new FilterTokenStrict().operator(resultOp).value(user.getUserId()));
+                }
+            }
+        }
+        return result;
+    }
+
+    private record ResolvedFilters(List<FilterToken> filters, Set<String> excludedUserIds) {}
+
+    private ResolvedFilters resolveLoginUsernameFiltersToUserIdFilters(List<FilterToken> loginUsernameFilters) {
+        List<FilterToken> filters = new ArrayList<>();
+        Set<String> excludedUserIds = new HashSet<>();
+
+        for (FilterToken filter : loginUsernameFilters) {
+            FilterToken.OperatorEnum op = filter.getOperator();
+            FilterToken.OperatorEnum lookupOp = (op == FilterToken.OperatorEnum.CONTAINS || op == FilterToken.OperatorEnum.NOT_CONTAINS)
+                ? FilterToken.OperatorEnum.CONTAINS : FilterToken.OperatorEnum.EQUAL;
+
+            DescribeUsersRequestData userRequest = new DescribeUsersRequestData();
+            userRequest.setLoginUsernames(List.of(new FilterToken().operator(lookupOp).value(filter.getValue())));
+            List<User> users = userService.describeUsers(userRequest).getUsers();
+
+            if (users.isEmpty()) {
+                if (op == FilterToken.OperatorEnum.EQUAL || op == FilterToken.OperatorEnum.CONTAINS) {
+                    filters.add(filter);
+                }
+            } else if (op == FilterToken.OperatorEnum.NOT_CONTAINS) {
+                users.forEach(u -> excludedUserIds.add(u.getUserId()));
+            } else {
+                FilterToken.OperatorEnum resultOp = (op == FilterToken.OperatorEnum.CONTAINS)
+                    ? FilterToken.OperatorEnum.EQUAL : op;
+                for (User user : users) {
+                    filters.add(new FilterToken().operator(resultOp).value(user.getUserId()));
+                }
+            }
+        }
+        return new ResolvedFilters(filters, excludedUserIds);
     }
 }

--- a/dcv-access-console-handler/src/main/java/handler/controllers/DescribeSessionTemplatesController.java
+++ b/dcv-access-console-handler/src/main/java/handler/controllers/DescribeSessionTemplatesController.java
@@ -36,11 +36,14 @@ import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static handler.errors.CommonErrorsEnum.BAD_REQUEST_ERROR;
 import static handler.errors.DescribeSessionTemplatesErrors.DESCRIBE_SESSION_TEMPLATES_DEFAULT_MESSAGE;
@@ -183,24 +186,25 @@ public class DescribeSessionTemplatesController implements DescribeSessionTempla
     }
 
     private List<FilterTokenStrict> resolveLoginUsernameFiltersForUsersSharedWith(List<FilterToken> loginUsernameFilters) {
+        DescribeUsersRequestData userRequest = new DescribeUsersRequestData();
+        userRequest.setLoginUsernames(loginUsernameFilters.stream()
+            .map(f -> new FilterToken().operator(FilterToken.OperatorEnum.EQUAL).value(f.getValue()))
+            .toList());
+
+        List<User> users = userService.describeUsers(userRequest).getUsers();
+        Map<String, String> loginToUserId = users.stream()
+            .collect(Collectors.toMap(
+                u -> u.getLoginUsername() != null ? u.getLoginUsername() : u.getUserId(),
+                User::getUserId,
+                (a, b) -> a));
+
         List<FilterTokenStrict> result = new ArrayList<>();
         for (FilterToken filter : loginUsernameFilters) {
-            DescribeUsersRequestData userRequest = new DescribeUsersRequestData();
-            userRequest.setLoginUsernames(List.of(new FilterToken().operator(FilterToken.OperatorEnum.EQUAL).value(filter.getValue())));
-            List<User> users = userService.describeUsers(userRequest).getUsers();
-
-            if (users.isEmpty()) {
-                result.add(new FilterTokenStrict()
-                    .operator(FilterTokenStrict.OperatorEnum.fromValue(filter.getOperator().getValue()))
-                    .value(filter.getValue()));
-            } else {
-                FilterTokenStrict.OperatorEnum resultOp = filter.getOperator() == FilterToken.OperatorEnum.NOT_EQUAL
-                    ? FilterTokenStrict.OperatorEnum.NOT_EQUAL
-                    : FilterTokenStrict.OperatorEnum.EQUAL;
-                for (User user : users) {
-                    result.add(new FilterTokenStrict().operator(resultOp).value(user.getUserId()));
-                }
-            }
+            String userId = loginToUserId.get(filter.getValue());
+            FilterTokenStrict.OperatorEnum resultOp = filter.getOperator() == FilterToken.OperatorEnum.NOT_EQUAL
+                ? FilterTokenStrict.OperatorEnum.NOT_EQUAL
+                : FilterTokenStrict.OperatorEnum.EQUAL;
+            result.add(new FilterTokenStrict().operator(resultOp).value(userId != null ? userId : filter.getValue()));
         }
         return result;
     }
@@ -211,26 +215,56 @@ public class DescribeSessionTemplatesController implements DescribeSessionTempla
         List<FilterToken> filters = new ArrayList<>();
         Set<String> excludedUserIds = new HashSet<>();
 
+        // Group filters by lookup operator type to batch DB calls
+        Map<FilterToken.OperatorEnum, List<FilterToken>> filtersByLookupOp = new HashMap<>();
+        filtersByLookupOp.put(FilterToken.OperatorEnum.EQUAL, new ArrayList<>());
+        filtersByLookupOp.put(FilterToken.OperatorEnum.CONTAINS, new ArrayList<>());
+
         for (FilterToken filter : loginUsernameFilters) {
             FilterToken.OperatorEnum op = filter.getOperator();
             FilterToken.OperatorEnum lookupOp = (op == FilterToken.OperatorEnum.CONTAINS || op == FilterToken.OperatorEnum.NOT_CONTAINS)
                 ? FilterToken.OperatorEnum.CONTAINS : FilterToken.OperatorEnum.EQUAL;
+            filtersByLookupOp.get(lookupOp).add(filter);
+        }
+
+
+        // Batch lookup for each operator type
+        for (var entry : filtersByLookupOp.entrySet()) {
+            if (entry.getValue().isEmpty()) continue;
+
+            FilterToken.OperatorEnum lookupOp = entry.getKey();
+            List<FilterToken> filtersForOp = entry.getValue();
 
             DescribeUsersRequestData userRequest = new DescribeUsersRequestData();
-            userRequest.setLoginUsernames(List.of(new FilterToken().operator(lookupOp).value(filter.getValue())));
+            userRequest.setLoginUsernames(filtersForOp.stream()
+                .map(f -> new FilterToken().operator(lookupOp).value(f.getValue()))
+                .toList());
+
             List<User> users = userService.describeUsers(userRequest).getUsers();
 
-            if (users.isEmpty()) {
-                if (op == FilterToken.OperatorEnum.EQUAL || op == FilterToken.OperatorEnum.CONTAINS) {
-                    filters.add(filter);
-                }
-            } else if (op == FilterToken.OperatorEnum.NOT_CONTAINS) {
-                users.forEach(u -> excludedUserIds.add(u.getUserId()));
-            } else {
-                FilterToken.OperatorEnum resultOp = (op == FilterToken.OperatorEnum.CONTAINS)
-                    ? FilterToken.OperatorEnum.EQUAL : op;
-                for (User user : users) {
-                    filters.add(new FilterToken().operator(resultOp).value(user.getUserId()));
+            for (FilterToken filter : filtersForOp) {
+                FilterToken.OperatorEnum op = filter.getOperator();
+                String filterVal = filter.getValue();
+                
+                List<User> matchingUsers = users.stream().filter(u -> {
+                    String displayName = u.getLoginUsername() != null ? u.getLoginUsername() : u.getUserId();
+                    if (displayName == null) return false;
+                    return lookupOp == FilterToken.OperatorEnum.EQUAL
+                        ? displayName.equals(filterVal)
+                        : displayName.contains(filterVal);
+                }).toList();
+
+                if (matchingUsers.isEmpty()) {
+                    if (op == FilterToken.OperatorEnum.EQUAL || op == FilterToken.OperatorEnum.CONTAINS) {
+                        filters.add(filter);
+                    }
+                } else if (op == FilterToken.OperatorEnum.NOT_CONTAINS) {
+                    matchingUsers.forEach(u -> excludedUserIds.add(u.getUserId()));
+                } else {
+                    FilterToken.OperatorEnum resultOp = (op == FilterToken.OperatorEnum.CONTAINS)
+                        ? FilterToken.OperatorEnum.EQUAL : op;
+                    matchingUsers.forEach(u -> 
+                        filters.add(new FilterToken().operator(resultOp).value(u.getUserId())));
                 }
             }
         }

--- a/dcv-access-console-handler/src/main/java/handler/controllers/DescribeUserInfoController.java
+++ b/dcv-access-console-handler/src/main/java/handler/controllers/DescribeUserInfoController.java
@@ -54,9 +54,11 @@ public class DescribeUserInfoController implements DescribeUserInfoApi {
         try {
             String username = SecurityContextHolder.getContext().getAuthentication().getName();
 
+            boolean usingExternalAuth = false;
             if ((StringUtils.isNotEmpty(loginUsernameKey) || StringUtils.isNotEmpty(displayNameKey) 
                     || StringUtils.isNotEmpty(roleKey) || StringUtils.isNotEmpty(defaultGroupsKey))
                     && authServerClientService != null) {
+                usingExternalAuth = true;
                 updateUserFromAuthServer(username);
             }
 
@@ -70,7 +72,8 @@ public class DescribeUserInfoController implements DescribeUserInfoApi {
                     .id(username)
                     .loginUsername(loginUsername)
                     .displayName(displayName)
-                    .role(role);
+                    .role(role)
+                    .usingExternalAuth(usingExternalAuth);
             return new ResponseEntity<>(describeCurrentUserResponse, HttpStatus.OK);
         } catch (UsernameNotFoundException e) {
             return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);

--- a/dcv-access-console-handler/src/main/java/handler/controllers/DescribeUsersSharedWithSessionTemplateController.java
+++ b/dcv-access-console-handler/src/main/java/handler/controllers/DescribeUsersSharedWithSessionTemplateController.java
@@ -83,7 +83,7 @@ public class DescribeUsersSharedWithSessionTemplateController implements Describ
                     .collect(Collectors.toList());
             if (!userIds.isEmpty()) {
                 DescribeUsersResponse describeUsersResponse = userService.describeUsers(
-                        new DescribeUsersRequestData().internalUserIds(userIds).nextToken(request.getNextToken()));
+                        new DescribeUsersRequestData().userIds(userIds).nextToken(request.getNextToken()));
                 log.info("DescribeUsersResponse for: {} is: {}", userIds, describeUsersResponse.getUsers());
                 response.setUsers(describeUsersResponse.getUsers().stream().map(user -> new UserWithPermissions().userId(user.getUserId()).loginUsername(user.getLoginUsername()).displayName(user.getDisplayName())).toList());
             } else {

--- a/dcv-access-console-handler/src/main/java/handler/controllers/DescribeUsersSharedWithSessionTemplateController.java
+++ b/dcv-access-console-handler/src/main/java/handler/controllers/DescribeUsersSharedWithSessionTemplateController.java
@@ -83,7 +83,7 @@ public class DescribeUsersSharedWithSessionTemplateController implements Describ
                     .collect(Collectors.toList());
             if (!userIds.isEmpty()) {
                 DescribeUsersResponse describeUsersResponse = userService.describeUsers(
-                        new DescribeUsersRequestData().userIds(userIds).nextToken(request.getNextToken()));
+                        new DescribeUsersRequestData().internalUserIds(userIds).nextToken(request.getNextToken()));
                 log.info("DescribeUsersResponse for: {} is: {}", userIds, describeUsersResponse.getUsers());
                 response.setUsers(describeUsersResponse.getUsers().stream().map(user -> new UserWithPermissions().userId(user.getUserId()).loginUsername(user.getLoginUsername()).displayName(user.getDisplayName())).toList());
             } else {

--- a/dcv-access-console-handler/src/main/java/handler/utils/Filter.java
+++ b/dcv-access-console-handler/src/main/java/handler/utils/Filter.java
@@ -122,8 +122,8 @@ public class Filter<T, U> {
                 entry("disableRetryOnFailure", new String[]{"disableRetryOnFailure"})
             )),
             entry(DescribeUsersRequestData.class, Map.ofEntries(
-                    entry("userIds", new String[]{"loginUsername", "userId"}),
-                    entry("internalUserIds", new String[]{"userId"}),
+                    entry("loginUsernames", new String[]{"loginUsername", "userId"}),
+                    entry("userIds", new String[]{"userId"}),
                     entry("displayNames", new String[]{"displayName"}),
                     entry("roles", new String[]{"role"}),
                     entry("isDisabled", new String[]{"isDisabled"}),

--- a/dcv-access-console-handler/src/main/java/handler/utils/Filter.java
+++ b/dcv-access-console-handler/src/main/java/handler/utils/Filter.java
@@ -122,7 +122,8 @@ public class Filter<T, U> {
                 entry("disableRetryOnFailure", new String[]{"disableRetryOnFailure"})
             )),
             entry(DescribeUsersRequestData.class, Map.ofEntries(
-                    entry("userIds", new String[]{"userId"}),
+                    entry("userIds", new String[]{"loginUsername", "userId"}),
+                    entry("internalUserIds", new String[]{"userId"}),
                     entry("displayNames", new String[]{"displayName"}),
                     entry("roles", new String[]{"role"}),
                     entry("isDisabled", new String[]{"isDisabled"}),
@@ -320,9 +321,6 @@ public class Filter<T, U> {
     private boolean isFiltered(U obj, String[] property, Object filter) {
         try {
             Object object = PropertyAccessorFactory.forBeanPropertyAccess(obj).getPropertyValue(property[0]);
-            if(object == null) {
-                return false;
-            }
             if(object instanceof List objects) {
                 for(Object objectProperty: objects) {
                     if(objectProperty != null) {
@@ -342,7 +340,13 @@ public class Filter<T, U> {
                 return false;
             }
             else {
-                return filter(object, filter);
+                for (String prop : property) {
+                    Object value = PropertyAccessorFactory.forBeanPropertyAccess(obj).getPropertyValue(prop);
+                    if (value != null) {
+                        return filter(value, filter);
+                    }
+                }
+                return false;
             }
         }
         catch(NullValueInNestedPathException e) {

--- a/dcv-access-console-handler/src/main/java/handler/utils/Sort.java
+++ b/dcv-access-console-handler/src/main/java/handler/utils/Sort.java
@@ -16,13 +16,26 @@ import java.util.List;
 
 @Component
 public class Sort<T, U> {
+    private static final String USER_ID_KEY = "UserId";
+    private static final String LOGIN_USERNAME_PROPERTY = "loginUsername";
+    private static final String USER_ID_PROPERTY = "userId";
+
     @AllArgsConstructor
     private class ValueComparator implements Comparator<U> {
         private SortToken sortToken;
         @Override
         public int compare(U o1, U o2) {
-            Object propertyValue1 = PropertyAccessorFactory.forBeanPropertyAccess(o1).getPropertyValue(sortToken.getKey());
-            Object propertyValue2 = PropertyAccessorFactory.forBeanPropertyAccess(o2).getPropertyValue(sortToken.getKey());
+            Object propertyValue1;
+            Object propertyValue2;
+            
+            if (USER_ID_KEY.equals(sortToken.getKey())) {
+                propertyValue1 = getLoginUsernameOrUserId(o1);
+                propertyValue2 = getLoginUsernameOrUserId(o2);
+            } else {
+                propertyValue1 = PropertyAccessorFactory.forBeanPropertyAccess(o1).getPropertyValue(sortToken.getKey());
+                propertyValue2 = PropertyAccessorFactory.forBeanPropertyAccess(o2).getPropertyValue(sortToken.getKey());
+            }
+            
             if(propertyValue1 == null && propertyValue2 == null) {
                 return 0;
             }
@@ -45,6 +58,12 @@ public class Sort<T, U> {
                 return value1.compareTo((Boolean) propertyValue2);
             }
             throw new UnsupportedOperationException("Failed to sort: Sorting not defined for " + propertyValue1.getClass());
+        }
+        
+        private Object getLoginUsernameOrUserId(U obj) {
+            Object loginUsername = PropertyAccessorFactory.forBeanPropertyAccess(obj).getPropertyValue(LOGIN_USERNAME_PROPERTY);
+            if (loginUsername != null) return loginUsername;
+            return PropertyAccessorFactory.forBeanPropertyAccess(obj).getPropertyValue(USER_ID_PROPERTY);
         }
     }
 

--- a/dcv-access-console-handler/src/test/java/handler/controllers/DescribeSessionTemplatesControllerTest.java
+++ b/dcv-access-console-handler/src/test/java/handler/controllers/DescribeSessionTemplatesControllerTest.java
@@ -163,4 +163,118 @@ public class DescribeSessionTemplatesControllerTest extends BaseControllerTest {
 
         verify(mockUserService).describeUsers(any());
     }
+
+    @Test
+    public void describeSessionTemplatesWithNotContainsFilter_excludesMatchingTemplates() throws Exception {
+        SessionTemplate includedTemplate = new SessionTemplate().id("included").createdBy("other-user");
+        SessionTemplate excludedTemplate = new SessionTemplate().id("excluded").createdBy("uuid-admin");
+        List<SessionTemplate> allTemplates = new ArrayList<>(List.of(includedTemplate, excludedTemplate));
+
+        when(mockUserService.describeUsers(any())).thenReturn(
+            new DescribeUsersResponse().users(List.of(new User().userId("uuid-admin").loginUsername("admin")))
+        );
+        when(mockSessionTemplateService.describeSessionTemplates(any())).thenReturn(
+            new DescribeSessionTemplatesResponse().sessionTemplates(allTemplates).nextToken(null)
+        );
+        // After preFilterExclusions, only includedTemplate remains
+        when(mockSessionFilter.getFiltered(any(), any())).thenReturn(List.of(includedTemplate));
+        when(mockSessionSort.getSorted(any(), any())).thenAnswer(i -> i.getArguments()[1]);
+        when(mockAuthorizationEngine.isAuthorized(PrincipalType.User, testUser, ResourceAction.viewSessionTemplateDetails, ResourceType.SessionTemplate, "included")).thenReturn(true);
+
+        mvc.perform(
+                post(urlTemplate)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.ORIGIN, origin)
+                    .content("{\"CreatedByLoginUsername\": [{\"Operator\": \"NOT_CONTAINS\", \"Value\": \"admin\"}]}"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.SessionTemplates", hasSize(1)))
+            .andExpect(jsonPath("$.SessionTemplates[0].Id", is("included")));
+    }
+
+    @Test
+    public void describeSessionTemplatesWithContainsFilter_resolvesToMultipleUsers() throws Exception {
+        SessionTemplate template1 = new SessionTemplate().id("t1").createdBy("uuid-admin1");
+        SessionTemplate template2 = new SessionTemplate().id("t2").createdBy("uuid-admin2");
+        List<SessionTemplate> templates = new ArrayList<>(List.of(template1, template2));
+
+        // CONTAINS "admin" returns multiple users
+        when(mockUserService.describeUsers(any())).thenReturn(
+            new DescribeUsersResponse().users(List.of(
+                new User().userId("uuid-admin1").loginUsername("admin1"),
+                new User().userId("uuid-admin2").loginUsername("admin2")
+            ))
+        );
+        when(mockSessionTemplateService.describeSessionTemplates(any())).thenReturn(
+            new DescribeSessionTemplatesResponse().sessionTemplates(templates).nextToken(null)
+        );
+        when(mockSessionFilter.getFiltered(any(), any())).thenReturn(templates);
+        when(mockSessionSort.getSorted(any(), any())).thenAnswer(i -> i.getArguments()[1]);
+        when(mockAuthorizationEngine.isAuthorized(any(), any(), any(), any(), any())).thenReturn(true);
+
+        mvc.perform(
+                post(urlTemplate)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.ORIGIN, origin)
+                    .content("{\"CreatedByLoginUsername\": [{\"Operator\": \"CONTAINS\", \"Value\": \"admin\"}]}"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.SessionTemplates", hasSize(2)));
+    }
+
+    @Test
+    public void describeSessionTemplatesWithUsersSharedWithLoginUsername_batchesLookup() throws Exception {
+        SessionTemplate template = new SessionTemplate().id(testString);
+        List<SessionTemplate> templates = new ArrayList<>(List.of(template));
+
+        when(mockUserService.describeUsers(any())).thenReturn(
+            new DescribeUsersResponse().users(List.of(
+                new User().userId("uuid-1").loginUsername("user1"),
+                new User().userId("uuid-2").loginUsername("user2")
+            ))
+        );
+        when(mockSessionTemplateService.describeSessionTemplates(any())).thenReturn(
+            new DescribeSessionTemplatesResponse().sessionTemplates(templates).nextToken(null)
+        );
+        when(mockSessionFilter.getFiltered(any(), any())).thenReturn(templates);
+        when(mockSessionSort.getSorted(any(), any())).thenAnswer(i -> i.getArguments()[1]);
+        when(mockAuthorizationEngine.isAuthorized(any(), any(), (SystemAction) any())).thenReturn(true);
+        when(mockAuthorizationEngine.isAuthorized(any(), any(), any(), any(), any())).thenReturn(true);
+
+        mvc.perform(
+                post(urlTemplate)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.ORIGIN, origin)
+                    .content("{\"UsersSharedWithLoginUsername\": [{\"Operator\": \"=\", \"Value\": \"user1\"}, {\"Operator\": \"=\", \"Value\": \"user2\"}]}"))
+            .andExpect(status().isOk());
+
+        // Should make only 1 batched call, not 2 separate calls
+        verify(mockUserService).describeUsers(any());
+    }
+
+    @Test
+    public void describeSessionTemplatesWithCreatedByLoginUsername_batchesByOperatorType() throws Exception {
+        SessionTemplate template = new SessionTemplate().id(testString).createdBy("uuid-1");
+        List<SessionTemplate> templates = new ArrayList<>(List.of(template));
+
+        // Mock returns user for both EQUAL and CONTAINS lookups
+        when(mockUserService.describeUsers(any())).thenReturn(
+            new DescribeUsersResponse().users(List.of(new User().userId("uuid-1").loginUsername("user1")))
+        );
+        when(mockSessionTemplateService.describeSessionTemplates(any())).thenReturn(
+            new DescribeSessionTemplatesResponse().sessionTemplates(templates).nextToken(null)
+        );
+        when(mockSessionFilter.getFiltered(any(), any())).thenReturn(templates);
+        when(mockSessionSort.getSorted(any(), any())).thenAnswer(i -> i.getArguments()[1]);
+        when(mockAuthorizationEngine.isAuthorized(any(), any(), any(), any(), any())).thenReturn(true);
+
+        // 2 EQUAL filters + 1 CONTAINS filter = max 2 DB calls (one per operator type)
+        mvc.perform(
+                post(urlTemplate)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.ORIGIN, origin)
+                    .content("{\"CreatedByLoginUsername\": [{\"Operator\": \"=\", \"Value\": \"user1\"}, {\"Operator\": \"=\", \"Value\": \"user2\"}, {\"Operator\": \"CONTAINS\", \"Value\": \"user\"}]}"))
+            .andExpect(status().isOk());
+
+        // Should make 2 batched calls (EQUAL bucket + CONTAINS bucket), not 3
+        verify(mockUserService, org.mockito.Mockito.times(2)).describeUsers(any());
+    }
 }

--- a/dcv-access-console-handler/src/test/java/handler/controllers/DescribeSessionTemplatesControllerTest.java
+++ b/dcv-access-console-handler/src/test/java/handler/controllers/DescribeSessionTemplatesControllerTest.java
@@ -9,9 +9,12 @@ import handler.authorization.enums.ResourceType;
 import handler.authorization.enums.SystemAction;
 import handler.exceptions.BadRequestException;
 import handler.services.SessionTemplateService;
+import handler.services.UserService;
 import handler.model.SessionTemplate;
 import handler.model.DescribeSessionTemplatesRequestData;
 import handler.model.DescribeSessionTemplatesResponse;
+import handler.model.DescribeUsersResponse;
+import handler.model.User;
 import handler.utils.Filter;
 import handler.utils.Sort;
 
@@ -49,6 +52,8 @@ public class DescribeSessionTemplatesControllerTest extends BaseControllerTest {
     private Filter<DescribeSessionTemplatesRequestData, SessionTemplate> mockSessionFilter;
     @MockBean
     private Sort<DescribeSessionTemplatesRequestData, SessionTemplate> mockSessionSort;
+    @MockBean
+    private UserService mockUserService;
 
     @Value("${web-client-url}")
     private String origin;
@@ -128,5 +133,34 @@ public class DescribeSessionTemplatesControllerTest extends BaseControllerTest {
 
         verify(mockSessionTemplateService).filterByUserId(any(), any());
         verify(mockSessionTemplateService).filterByGroupId(any(), any());
+    }
+
+    @Test
+    public void describeSessionTemplatesWithLoginUsernameFilter() throws Exception {
+        List<SessionTemplate> sessionTemplates = new ArrayList<>();
+        SessionTemplate sessionTemplate = new SessionTemplate().id(testString).createdBy("uuid-123");
+        sessionTemplates.add(sessionTemplate);
+
+        // Mock user lookup: loginUsername "newuser" -> userId "uuid-123"
+        when(mockUserService.describeUsers(any())).thenReturn(
+            new DescribeUsersResponse().users(List.of(new User().userId("uuid-123").loginUsername("newuser")))
+        );
+        when(mockSessionTemplateService.describeSessionTemplates(any())).thenReturn(
+            new DescribeSessionTemplatesResponse().sessionTemplates(sessionTemplates).nextToken(null)
+        );
+        when(mockSessionFilter.getFiltered(any(), any())).thenReturn(sessionTemplates);
+        when(mockSessionSort.getSorted(any(), any())).thenAnswer(i -> i.getArguments()[1]);
+        when(mockAuthorizationEngine.isAuthorized(PrincipalType.User, testUser, ResourceAction.viewSessionTemplateDetails, ResourceType.SessionTemplate, testString)).thenReturn(true);
+
+        mvc.perform(
+                post(urlTemplate)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.ORIGIN, origin)
+                    .content("{\"CreatedByLoginUsername\": [{\"Operator\": \"=\", \"Value\": \"newuser\"}]}"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.SessionTemplates", hasSize(1)))
+            .andExpect(jsonPath("$.SessionTemplates[0].Id", is(testString)));
+
+        verify(mockUserService).describeUsers(any());
     }
 }

--- a/dcv-access-console-handler/src/test/java/handler/utils/FilterTest.java
+++ b/dcv-access-console-handler/src/test/java/handler/utils/FilterTest.java
@@ -425,32 +425,32 @@ public class FilterTest {
 
         // Filter by loginUsername (EQUAL)
         FilterToken filterToken = new FilterToken().operator(FilterToken.OperatorEnum.EQUAL).value("user1");
-        userRequest.addUserIdsItem(filterToken);
+        userRequest.addLoginUsernamesItem(filterToken);
         List<User> filtered = testUserFilter.getFiltered(userRequest, users);
         assertEquals(1, filtered.size());
         assertEquals(user1, filtered.get(0));
 
         // Filter by userId when no loginUsername (EQUAL)
-        userRequest.setUserIds(null);
+        userRequest.setLoginUsernames(null);
         filterToken = new FilterToken().operator(FilterToken.OperatorEnum.EQUAL).value("uuid-2");
-        userRequest.addUserIdsItem(filterToken);
+        userRequest.addLoginUsernamesItem(filterToken);
         filtered = testUserFilter.getFiltered(userRequest, users);
         assertEquals(1, filtered.size());
         assertEquals(user2, filtered.get(0));
 
         // Filter by loginUsername (NOT_EQUAL) - excludes user1, includes user2 and user3
-        userRequest.setUserIds(null);
+        userRequest.setLoginUsernames(null);
         filterToken = new FilterToken().operator(FilterToken.OperatorEnum.NOT_EQUAL).value("user1");
-        userRequest.addUserIdsItem(filterToken);
+        userRequest.addLoginUsernamesItem(filterToken);
         filtered = testUserFilter.getFiltered(userRequest, users);
         assertEquals(2, filtered.size());
         assertEquals(user2, filtered.get(0));
         assertEquals(user3, filtered.get(1));
 
         // Filter by userId (NOT_EQUAL) on user without loginUsername
-        userRequest.setUserIds(null);
+        userRequest.setLoginUsernames(null);
         filterToken = new FilterToken().operator(FilterToken.OperatorEnum.NOT_EQUAL).value("uuid-2");
-        userRequest.addUserIdsItem(filterToken);
+        userRequest.addLoginUsernamesItem(filterToken);
         filtered = testUserFilter.getFiltered(userRequest, users);
         assertEquals(2, filtered.size());
         assertEquals(user1, filtered.get(0));

--- a/dcv-access-console-handler/src/test/java/handler/utils/FilterTest.java
+++ b/dcv-access-console-handler/src/test/java/handler/utils/FilterTest.java
@@ -44,6 +44,8 @@ import handler.model.State;
 import handler.model.Type;
 import handler.model.UnavailabilityReason;
 import handler.model.SessionTemplate;
+import handler.model.User;
+import handler.model.DescribeUsersRequestData;
 
 @ExtendWith(MockitoExtension.class)
 public class FilterTest {
@@ -55,6 +57,8 @@ public class FilterTest {
     private Filter<DescribeSessionTemplatesRequestData, SessionTemplate> testSessionTemplateFilter;
     @InjectMocks
     private Filter<GetSessionScreenshotsUIRequestData, Session> badTestFilter;
+    @InjectMocks
+    private Filter<DescribeUsersRequestData, User> testUserFilter;
     private static List<Session> unfilteredSessions;
     private static List<Session> firstFilteredSession;
     private static List<Session> secondFilteredSession;
@@ -404,5 +408,52 @@ public class FilterTest {
         filterBooleanToken = new FilterBooleanToken().operator(FilterBooleanToken.OperatorEnum.NOT_EQUAL).value(false);
         filteredSessionTemplates = testSessionTemplateFilter.getFiltered(sessionTemplateRequest.addDcvGlEnabledItem(filterBooleanToken), unfilteredSessionTemplates);
         assertEquals(filteredSessionTemplate, filteredSessionTemplates);
+    }
+
+    @Test
+    public void testUserFilterWithFallback() {
+        User user1 = new User().loginUsername("user1").userId("uuid-1");
+        User user2 = new User().userId("uuid-2");
+        User user3 = new User().loginUsername("user3").userId("uuid-3");
+
+        List<User> users = new ArrayList<>();
+        users.add(user1);
+        users.add(user2);
+        users.add(user3);
+
+        DescribeUsersRequestData userRequest = new DescribeUsersRequestData();
+
+        // Filter by loginUsername (EQUAL)
+        FilterToken filterToken = new FilterToken().operator(FilterToken.OperatorEnum.EQUAL).value("user1");
+        userRequest.addUserIdsItem(filterToken);
+        List<User> filtered = testUserFilter.getFiltered(userRequest, users);
+        assertEquals(1, filtered.size());
+        assertEquals(user1, filtered.get(0));
+
+        // Filter by userId when no loginUsername (EQUAL)
+        userRequest.setUserIds(null);
+        filterToken = new FilterToken().operator(FilterToken.OperatorEnum.EQUAL).value("uuid-2");
+        userRequest.addUserIdsItem(filterToken);
+        filtered = testUserFilter.getFiltered(userRequest, users);
+        assertEquals(1, filtered.size());
+        assertEquals(user2, filtered.get(0));
+
+        // Filter by loginUsername (NOT_EQUAL) - excludes user1, includes user2 and user3
+        userRequest.setUserIds(null);
+        filterToken = new FilterToken().operator(FilterToken.OperatorEnum.NOT_EQUAL).value("user1");
+        userRequest.addUserIdsItem(filterToken);
+        filtered = testUserFilter.getFiltered(userRequest, users);
+        assertEquals(2, filtered.size());
+        assertEquals(user2, filtered.get(0));
+        assertEquals(user3, filtered.get(1));
+
+        // Filter by userId (NOT_EQUAL) on user without loginUsername
+        userRequest.setUserIds(null);
+        filterToken = new FilterToken().operator(FilterToken.OperatorEnum.NOT_EQUAL).value("uuid-2");
+        userRequest.addUserIdsItem(filterToken);
+        filtered = testUserFilter.getFiltered(userRequest, users);
+        assertEquals(2, filtered.size());
+        assertEquals(user1, filtered.get(0));
+        assertEquals(user3, filtered.get(1));
     }
 }

--- a/dcv-access-console-handler/src/test/java/handler/utils/SortTest.java
+++ b/dcv-access-console-handler/src/test/java/handler/utils/SortTest.java
@@ -5,7 +5,9 @@ package handler.utils;
 
 import handler.model.Session;
 import handler.model.Server;
+import handler.model.User;
 import handler.model.DescribeSessionsUIRequestData;
+import handler.model.DescribeUsersRequestData;
 import handler.model.GetSessionScreenshotsUIRequestData;
 import handler.model.SortToken;
 import handler.exceptions.BadRequestException;
@@ -28,6 +30,8 @@ public class SortTest {
     private Sort<DescribeSessionsUIRequestData, Session> testSort;
     @InjectMocks
     private Sort<GetSessionScreenshotsUIRequestData, Session> testBadRequestTypeSort;
+    @InjectMocks
+    private Sort<DescribeUsersRequestData, User> testUserSort;
     private static List<Session> unsortedSessions;
     private static List<Session> sortedAscSessions;
     private static SortToken token;
@@ -113,5 +117,35 @@ public class SortTest {
         request.setSortToken(null);
         sorted = testSort.getSorted(request, unsortedSessions);
         assertEquals(unsortedSessions, sorted);
+    }
+
+    @Test
+    public void testUserSortByUserIdWithFallback() {
+        User user1 = new User().loginUsername("user1").userId("uuid-1");
+        User user2 = new User().userId("user2");
+        User user3 = new User().loginUsername("user3").userId("uuid-3");
+
+        List<User> users = new ArrayList<>();
+        users.add(user3);
+        users.add(user1);
+        users.add(user2);
+
+        SortToken userToken = new SortToken();
+        userToken.setOperator(SortToken.OperatorEnum.ASC);
+        userToken.setKey("UserId");
+
+        DescribeUsersRequestData userRequest = new DescribeUsersRequestData();
+        userRequest.setSortToken(userToken);
+
+        List<User> sorted = testUserSort.getSorted(userRequest, users);
+        assertEquals(user1, sorted.get(0));
+        assertEquals(user2, sorted.get(1));
+        assertEquals(user3, sorted.get(2));
+
+        userToken.setOperator(SortToken.OperatorEnum.DESC);
+        sorted = testUserSort.getSorted(userRequest, users);
+        assertEquals(user3, sorted.get(0));
+        assertEquals(user2, sorted.get(1));
+        assertEquals(user1, sorted.get(2));
     }
 }

--- a/dcv-access-console-model/model/dcv-access-console-handler-api.yaml
+++ b/dcv-access-console-model/model/dcv-access-console-handler-api.yaml
@@ -2029,7 +2029,12 @@ components:
       description: "The entity that represents the data that the user passes for describing the users"
       properties:
         UserIds:
-          description: "FilterTokens to apply for the UserId, 'OR' operator is applied for the specified tokens in the array"
+          description: "FilterTokens to apply for LoginUsername with userId fallback, 'OR' operator is applied for the specified tokens in the array"
+          type: "array"
+          items:
+            $ref: "#/components/schemas/FilterToken"
+        InternalUserIds:
+          description: "FilterTokens to apply for internal userId lookups (matches userId field only, for system use like resolving display names), 'OR' operator is applied for the specified tokens in the array"
           type: "array"
           items:
             $ref: "#/components/schemas/FilterToken"

--- a/dcv-access-console-model/model/dcv-access-console-handler-api.yaml
+++ b/dcv-access-console-model/model/dcv-access-console-handler-api.yaml
@@ -1640,6 +1640,11 @@ components:
           type: "array"
           items:
             $ref: "#/components/schemas/FilterToken"
+        CreatedByLoginUsername:
+          description: "FilterTokens to apply for the SessionTemplate creator's LoginUsername. Resolved to UserId internally. 'OR' operator is applied for the specified tokens in the array"
+          type: "array"
+          items:
+            $ref: "#/components/schemas/FilterToken"
         CreationTimes:
           description: "FilterTokens to apply for the SessionTemplate CreationTime, 'OR' operator is applied for the specified tokens in the array"
           type: "array"
@@ -1697,6 +1702,11 @@ components:
             $ref: "#/components/schemas/FilterDateToken"
         LastModifiedBy:
           description: "FilterTokens to apply for the SessionTemplate ModifiedBy, 'OR' operator is applied for the specified tokens in the array"
+          type: "array"
+          items:
+            $ref: "#/components/schemas/FilterToken"
+        LastModifiedByLoginUsername:
+          description: "FilterTokens to apply for the SessionTemplate last modifier's LoginUsername. Resolved to UserId internally. 'OR' operator is applied for the specified tokens in the array"
           type: "array"
           items:
             $ref: "#/components/schemas/FilterToken"
@@ -1760,6 +1770,11 @@ components:
           type: "array"
           items:
             $ref: "#/components/schemas/FilterTokenStrict"
+        UsersSharedWithLoginUsername:
+          description: "FilterTokens to apply for a User's LoginUsername that the SessionTemplate has been shared with. Resolved to UserId internally. 'OR' operator is applied for the specified tokens in the array"
+          type: "array"
+          items:
+            $ref: "#/components/schemas/FilterToken"
         GroupsSharedWith:
           description: "FilterTokens to apply for a Group that the SessionTemplate has been shared with, 'OR' operator is applied for the specified tokens in the array"
           type: "array"
@@ -1975,6 +1990,9 @@ components:
         Role:
           description: "The role of the current user"
           type: "string"
+        UsingExternalAuth:
+          description: "Whether the system is using external OAuth authentication (e.g., Cognito)"
+          type: "boolean"
     DeleteSessionUIRequestData:
       description: "The entity the contains the data on which Sessions to delete"
       type: "object"
@@ -2028,13 +2046,13 @@ components:
     DescribeUsersRequestData:
       description: "The entity that represents the data that the user passes for describing the users"
       properties:
-        UserIds:
+        LoginUsernames:
           description: "FilterTokens to apply for LoginUsername with userId fallback, 'OR' operator is applied for the specified tokens in the array"
           type: "array"
           items:
             $ref: "#/components/schemas/FilterToken"
-        InternalUserIds:
-          description: "FilterTokens to apply for internal userId lookups (matches userId field only, for system use like resolving display names), 'OR' operator is applied for the specified tokens in the array"
+        UserIds:
+          description: "FilterTokens to apply for the UserId, 'OR' operator is applied for the specified tokens in the array"
           type: "array"
           items:
             $ref: "#/components/schemas/FilterToken"

--- a/dcv-access-console-web-client/server/src/app/admin/sessionTemplates/[id]/page.tsx
+++ b/dcv-access-console-web-client/server/src/app/admin/sessionTemplates/[id]/page.tsx
@@ -19,6 +19,7 @@ import {useFlashBarContext} from "@/context-providers/FlashBarContext";
 import SessionTemplateDetails from "@/components/session-templates/session-template-details/SessionTemplateDetails";
 import usePageLoading from "@/components/common/hooks/PageLoadingHook";
 import LoadingSkeleton from "@/components/common/loadingSkeleton/LoadingSkeleton";
+import {useSession} from "next-auth/react";
 
 export default function SessionTemplate({params}: { params: { id: string } }) {
     const [sessionTemplate, setSessionTemplate] = useState<SessionTemplate>()
@@ -26,6 +27,8 @@ export default function SessionTemplate({params}: { params: { id: string } }) {
     const [error, setError] = useState(false);
     const {items, addFlashBar} = useFlashBarContext()
     const {loading: pageLoading, userSession} = usePageLoading()
+    const {data: session} = useSession()
+    const usingExternalAuth = session?.usingExternalAuth === true
 
     const getSessionTemplate = () => {
         const dataAccessService = new DataAccessService();
@@ -38,20 +41,25 @@ export default function SessionTemplate({params}: { params: { id: string } }) {
             ],
             MaxResults: 1
         }
-        dataAccessService.describeSessionTemplates(describeSessionTemplatesRequest).then(r => {
-            if (r.data.SessionTemplates) {
-                setSessionTemplate(r.data.SessionTemplates[0])
-                setLoading(false)
-            } else {
+        dataAccessService.describeSessionTemplates(describeSessionTemplatesRequest)
+            .then(async r => {
+                if (r.data.SessionTemplates && r.data.SessionTemplates.length > 0) {
+                    const template = r.data.SessionTemplates[0]
+                    if (usingExternalAuth) {
+                        await dataAccessService.replaceUserIdsWithLoginUsernames([template])
+                    }
+                    setSessionTemplate(template)
+                    setLoading(false)
+                } else {
+                    setLoading(false)
+                    setError(true)
+                }
+            }).catch(() => {
                 setLoading(false)
                 setError(true)
-            }
-        }).catch(() => {
-            setLoading(false)
-            setError(true)
-        })
+            })
     }
-    useEffect(() => getSessionTemplate(), [])
+    useEffect(() => getSessionTemplate(), [usingExternalAuth])
 
     if(pageLoading) return <LoadingSkeleton/>
     return (

--- a/dcv-access-console-web-client/server/src/app/api/auth/[...nextauth]/route.tsx
+++ b/dcv-access-console-web-client/server/src/app/api/auth/[...nextauth]/route.tsx
@@ -137,12 +137,14 @@ export const authOptions: NextAuthOptions = {
                 if(!user) {
                     throw "Error while contacting the handler"
                 }
+                console.log(`[Auth] describeUserInfo response: usingExternalAuth=${user.UsingExternalAuth}`)
                 return {
                     UserInfo: {
                         id: user.Id,
                         loginUsername: user.LoginUsername,
                         displayName: user.DisplayName,
-                        role: user.Role
+                        role: user.Role,
+                        usingExternalAuth: user.UsingExternalAuth
                     }
                 } as UserinfoResponse
             }
@@ -173,6 +175,7 @@ export const authOptions: NextAuthOptions = {
                 token.loginUsername = profile.UserInfo.loginUsername
                 token.name = profile.UserInfo.displayName
                 token.userRole = profile.UserInfo.role
+                token.usingExternalAuth = profile.UserInfo.usingExternalAuth
             }
 
             // Return previous token if the access token has not expired yet
@@ -197,6 +200,7 @@ export const authOptions: NextAuthOptions = {
             session.logout_endpoint = logoutEndpoint
             session.client_id = process.env.SM_UI_AUTH_CLIENT_ID
             session.post_logout_uri = process.env.NEXTAUTH_URL
+            session.usingExternalAuth = token.usingExternalAuth
             return session
         },
     },

--- a/dcv-access-console-web-client/server/src/app/api/auth/[...nextauth]/route.tsx
+++ b/dcv-access-console-web-client/server/src/app/api/auth/[...nextauth]/route.tsx
@@ -137,7 +137,6 @@ export const authOptions: NextAuthOptions = {
                 if(!user) {
                     throw "Error while contacting the handler"
                 }
-                console.log(`[Auth] describeUserInfo response: usingExternalAuth=${user.UsingExternalAuth}`)
                 return {
                     UserInfo: {
                         id: user.Id,

--- a/dcv-access-console-web-client/server/src/components/common/filter-bar/FilterBar.tsx
+++ b/dcv-access-console-web-client/server/src/components/common/filter-bar/FilterBar.tsx
@@ -27,6 +27,7 @@ export type DescribeResponse = {
     nextToken: string
 }
 
+export type ValueToLabelMap = Map<string, string>;
 export type FilterBarProps = {
     filteringQuery: PropertyFilterProps.Query
     handlePropertyFilteringChange: NonCancelableEventHandler<PropertyFilterProps.Query>
@@ -36,6 +37,8 @@ export type FilterBarProps = {
     searchTokenToId: Map<string, string | string[]>
     filteringPlaceholder: string
     dataAccessServiceFunction:  (request: DescribeSessionsUIRequestData | DescribeServersUIRequestData | DescribeSessionTemplatesRequestData | DescribeUsersRequestData | DescribeUserGroupsRequestData) => Promise<DescribeResponse>
+    // Optional map of property keys to value-label mappings for displaying easier to read labels in dropdown and token chips
+    propertyValueToLabelMaps?: Map<string, ValueToLabelMap>
 }
 const MEMORY_FILTER_KEYS = ["MemoryTotalBytes", "MemoryUsedBytes", "SwapTotalBytes", "SwapUsedBytes"]
 export default function FilterBar(props: FilterBarProps) {
@@ -64,6 +67,23 @@ export default function FilterBar(props: FilterBarProps) {
     }
 
     const fetchFilteringOptions = async (filteringText: string, filteringProperty: string) => {
+        // Map is built when templates are fetched for CreatedBy/LastModifiedBy (UUID→loginUsername),
+        // so use the map instead of querying backend. This shows users from the current page in dropdown.
+        const labelMap = props.propertyValueToLabelMaps?.get(filteringProperty)
+        if (labelMap && labelMap.size > 0) {
+            const options: Array<FilteringOption> = []
+            labelMap.forEach((label, value) => {
+                options.push({
+                    propertyKey: filteringProperty,
+                    value: value,
+                    label: label
+                } as FilteringOption)
+            })
+            updateFilteringOptions(filteringText, filteringProperty, options)
+            setStatus('finished')
+            return
+        }
+
         let objectProperty = props.searchTokenToId.get(filteringProperty)
         if (!objectProperty) {
             console.debug("Property {} not supported for autofill", filteringProperty)
@@ -138,10 +158,28 @@ export default function FilterBar(props: FilterBarProps) {
         await fetchFilteringOptions(detail.filteringText, detail.filteringProperty?.key)
     }
 
+    const filteringPropertiesWithFormat = FILTERING_PROPERTIES.map(prop => {
+        // Apply value→label formatting to filter chips (e.g., show loginUsername instead of UUID)
+        const labelMap = props.propertyValueToLabelMaps?.get(prop.key)
+        if (labelMap) {
+            return {
+                ...prop,
+                operators: prop.operators.map((op: string | { operator: string }) => {
+                    const operator = typeof op === 'string' ? op : op.operator
+                    return {
+                        operator,
+                        format: (value: string) => labelMap.get(value) || value
+                    }
+                })
+            }
+        }
+        return prop
+    })
+
     return (
         <PropertyFilter
             i18nStrings={PROPERTY_FILTER_I18N_STRINGS}
-            filteringProperties={FILTERING_PROPERTIES}
+            filteringProperties={filteringPropertiesWithFormat}
             filteringOptions={filteringOptions}
             query={props.filteringQuery}
             onChange={props.handlePropertyFilteringChange}

--- a/dcv-access-console-web-client/server/src/components/common/filter-bar/FilterBar.tsx
+++ b/dcv-access-console-web-client/server/src/components/common/filter-bar/FilterBar.tsx
@@ -27,7 +27,6 @@ export type DescribeResponse = {
     nextToken: string
 }
 
-export type ValueToLabelMap = Map<string, string>;
 export type FilterBarProps = {
     filteringQuery: PropertyFilterProps.Query
     handlePropertyFilteringChange: NonCancelableEventHandler<PropertyFilterProps.Query>
@@ -37,8 +36,6 @@ export type FilterBarProps = {
     searchTokenToId: Map<string, string | string[]>
     filteringPlaceholder: string
     dataAccessServiceFunction:  (request: DescribeSessionsUIRequestData | DescribeServersUIRequestData | DescribeSessionTemplatesRequestData | DescribeUsersRequestData | DescribeUserGroupsRequestData) => Promise<DescribeResponse>
-    // Optional map of property keys to value-label mappings for displaying easier to read labels in dropdown and token chips
-    propertyValueToLabelMaps?: Map<string, ValueToLabelMap>
 }
 const MEMORY_FILTER_KEYS = ["MemoryTotalBytes", "MemoryUsedBytes", "SwapTotalBytes", "SwapUsedBytes"]
 export default function FilterBar(props: FilterBarProps) {
@@ -67,23 +64,6 @@ export default function FilterBar(props: FilterBarProps) {
     }
 
     const fetchFilteringOptions = async (filteringText: string, filteringProperty: string) => {
-        // Map is built when templates are fetched for CreatedBy/LastModifiedBy (UUID→loginUsername),
-        // so use the map instead of querying backend. This shows users from the current page in dropdown.
-        const labelMap = props.propertyValueToLabelMaps?.get(filteringProperty)
-        if (labelMap && labelMap.size > 0) {
-            const options: Array<FilteringOption> = []
-            labelMap.forEach((label) => {
-                options.push({
-                    propertyKey: filteringProperty,
-                    value: label,
-                    label: label
-                } as FilteringOption)
-            })
-            updateFilteringOptions(filteringText, filteringProperty, options)
-            setStatus('finished')
-            return
-        }
-
         let objectProperty = props.searchTokenToId.get(filteringProperty)
         if (!objectProperty) {
             console.debug("Property {} not supported for autofill", filteringProperty)

--- a/dcv-access-console-web-client/server/src/components/common/filter-bar/FilterBar.tsx
+++ b/dcv-access-console-web-client/server/src/components/common/filter-bar/FilterBar.tsx
@@ -72,10 +72,10 @@ export default function FilterBar(props: FilterBarProps) {
         const labelMap = props.propertyValueToLabelMaps?.get(filteringProperty)
         if (labelMap && labelMap.size > 0) {
             const options: Array<FilteringOption> = []
-            labelMap.forEach((label, value) => {
+            labelMap.forEach((label) => {
                 options.push({
                     propertyKey: filteringProperty,
-                    value: value,
+                    value: label,
                     label: label
                 } as FilteringOption)
             })
@@ -157,29 +157,10 @@ export default function FilterBar(props: FilterBarProps) {
         setStatus('loading')
         await fetchFilteringOptions(detail.filteringText, detail.filteringProperty?.key)
     }
-
-    const filteringPropertiesWithFormat = FILTERING_PROPERTIES.map(prop => {
-        // Apply value→label formatting to filter chips (e.g., show loginUsername instead of UUID)
-        const labelMap = props.propertyValueToLabelMaps?.get(prop.key)
-        if (labelMap) {
-            return {
-                ...prop,
-                operators: prop.operators.map((op: string | { operator: string }) => {
-                    const operator = typeof op === 'string' ? op : op.operator
-                    return {
-                        operator,
-                        format: (value: string) => labelMap.get(value) || value
-                    }
-                })
-            }
-        }
-        return prop
-    })
-
     return (
         <PropertyFilter
             i18nStrings={PROPERTY_FILTER_I18N_STRINGS}
-            filteringProperties={filteringPropertiesWithFormat}
+            filteringProperties={FILTERING_PROPERTIES}
             filteringOptions={filteringOptions}
             query={props.filteringQuery}
             onChange={props.handlePropertyFilteringChange}

--- a/dcv-access-console-web-client/server/src/components/common/hooks/DataAccessServiceHooks.ts
+++ b/dcv-access-console-web-client/server/src/components/common/hooks/DataAccessServiceHooks.ts
@@ -239,34 +239,34 @@ export function useServersService(params: DataAccessServiceParams<Server>): Data
 const USER_FILTER_KEYS = ['UsersSharedWith', 'CreatedBy', 'LastModifiedBy']
 const USERS_SHARED_WITH_KEY = 'UsersSharedWith'
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+const NOT_CONTAINS_OPERATOR = '!:'
+const CONTAINS_OPERATOR = ':'
+const EQUAL_OPERATOR = '='
+const NOT_EQUAL_OPERATOR = '!='
 
-// Helper: Resolve user filter token to userIds
-const resolveUserFilter = async (token: PropertyFilterToken, dataService: DataAccessService): Promise<{ token: PropertyFilterToken, userIds: string[] }> => {
-    const isUUID = UUID_REGEX.test(token.value)
-    const isContains = token.operator === ':' || token.operator === '!:'
+const resolveUserFilters = async (tokens: PropertyFilterToken[], dataService: DataAccessService) => {
+    if (tokens.length === 0) return []
     
-    // UUID from dropdown - use directly
-    if (isUUID && isContains) {
-        return { token, userIds: [token.value] }
-    }
-    
-    // CONTAINS - query backend for matching users
-    if (isContains) {
-        try {
-            const r = await dataService.describeUsers({ UserIds: [{ Operator: FilterTokenOperatorEnum.Contains, Value: token.value }] })
-            return { token, userIds: r.data.Users?.map(u => u.UserId).filter(Boolean) || [] }
-        } catch {
-            return { token, userIds: [] }
+    // UUIDs don't need resolution
+    const results = tokens.map(token => {
+        if (UUID_REGEX.test(token.value)) {
+            return Promise.resolve({ token, userIds: [token.value] })
         }
-    }
+        
+        const isContains = SPECIAL_OPERATORS.has(token.operator)
+        const operator = isContains ? FilterTokenOperatorEnum.Contains : FilterTokenOperatorEnum.Equal
+        
+        return dataService.describeUsers({ UserIds: [{ Operator: operator, Value: token.value }] })
+            .then(r => {
+                const userIds = isContains
+                    ? r.data.Users?.map(u => u.UserId).filter(Boolean) || []
+                    : [r.data.Users?.[0]?.UserId || token.value]
+                return { token, userIds }
+            })
+            .catch(() => ({ token, userIds: isContains ? [] : [token.value] }))
+    })
     
-    // EQUAL/NOT_EQUAL - resolve single user
-    try {
-        const r = await dataService.describeUsers({ UserIds: [{ Operator: FilterTokenOperatorEnum.Equal, Value: token.value }] })
-        return { token, userIds: [r.data.Users?.[0]?.UserId || token.value] }
-    } catch {
-        return { token, userIds: [token.value] }
-    }
+    return Promise.all(results)
 }
 
 // Fetches session templates with user lookup: resolves loginUsername→userId for filtering,
@@ -319,15 +319,15 @@ export function useSessionTemplatesService(params: DataAccessServiceParams<Sessi
             }
         })
 
-        const resolveUserFilters = userFilterTokens.length > 0
-            ? Promise.all(userFilterTokens.map(token => resolveUserFilter(token, dataService)))
-            : Promise.resolve([])
-
-        resolveUserFilters
+        resolveUserFilters(userFilterTokens, dataService)
             .then(resolvedTokens => {
-                // Send non-negated filters to backend
+                // NOT_CONTAINS handled client-side because backend ORs multiple filters:
+                // Example: "admin" matches admin2 (uuid1) and admin5 (uuid2)
+                //   Backend: (CreatedBy !: uuid1) OR (CreatedBy !: uuid2)
+                //   Template by uuid1: (!: uuid1=false) OR (!: uuid2=true) = TRUE (kept incorrectly!)
+                //   Need: (CreatedBy !: uuid1) AND (CreatedBy !: uuid2) → client-side filtering
                 resolvedTokens
-                    .filter(({ token }) => token.operator !== '!:')
+                    .filter(({ token }) => token.operator !== NOT_CONTAINS_OPERATOR)
                     .forEach(({ token, userIds }) => {
                         const key = token.propertyKey as keyof DescribeSessionTemplatesRequestData
                         const operator = SPECIAL_OPERATORS.get(token.operator) || token.operator
@@ -338,10 +338,10 @@ export function useSessionTemplatesService(params: DataAccessServiceParams<Sessi
                     .then(r => ({ r, resolvedTokens }))
             })
             .then(({ r, resolvedTokens }) => {
-                // Client-side filter for NOT CONTAINS (backend OR logic doesn't support it)
+                // Client-side NOT_CONTAINS filtering (see comment above for why)
                 let templates = r.data.SessionTemplates || []
                 resolvedTokens
-                    .filter(({ token }) => token.operator === '!:')
+                    .filter(({ token }) => token.operator === NOT_CONTAINS_OPERATOR)
                     .forEach(({ token, userIds }) => {
                         const key = token.propertyKey as keyof SessionTemplate
                         templates = templates.filter(t => !userIds.includes(t[key] as string))
@@ -350,7 +350,7 @@ export function useSessionTemplatesService(params: DataAccessServiceParams<Sessi
                 // Collect userIds for display name lookup
                 const userIds = [...new Set([
                     ...templates.flatMap(t => [t.CreatedBy, t.LastModifiedBy].filter(Boolean)),
-                    ...resolvedTokens.filter(({ token }) => token.operator === ':').flatMap(({ userIds }) => userIds)
+                    ...resolvedTokens.filter(({ token }) => token.operator === CONTAINS_OPERATOR).flatMap(({ userIds }) => userIds)
                 ])] as string[]
                 
                 return dataService.describeUsersByIds(userIds).then(map => ({ templates, map, resolvedTokens }))
@@ -358,7 +358,7 @@ export function useSessionTemplatesService(params: DataAccessServiceParams<Sessi
             .then(({ templates, map, resolvedTokens }) => {
                 // Add EQUAL/NOT_EQUAL filter users to map
                 resolvedTokens
-                    .filter(({ token }) => token.operator === '=' || token.operator === '!=')
+                    .filter(({ token }) => token.operator === EQUAL_OPERATOR || token.operator === NOT_EQUAL_OPERATOR)
                     .forEach(({ token, userIds }) => {
                         if (token.propertyKey !== USERS_SHARED_WITH_KEY) {
                             userIds.forEach(userId => {

--- a/dcv-access-console-web-client/server/src/components/common/hooks/DataAccessServiceHooks.ts
+++ b/dcv-access-console-web-client/server/src/components/common/hooks/DataAccessServiceHooks.ts
@@ -32,6 +32,13 @@ export type FILTER_TOKEN = FilterToken | FilterStateToken | FilterDateToken
 export type FILTER_TOKEN_OPERATOR = FilterTokenOperatorEnum | FilterDateTokenOperatorEnum | FilterStateTokenOperatorEnum
 export const DEFAULT_FILTERING_QUERY = { tokens: [], operation: 'and' } as PropertyFilterQuery
 
+// Helper to add a filter token to a request object
+const addFilterToRequest = <T extends Record<string, any>>(request: T, key: keyof T, operator: string, value: string) => {
+    const tokenArray: Array<FILTER_TOKEN> = (request[key] as Array<FILTER_TOKEN>) || []
+    tokenArray.push({ Operator: operator as FILTER_TOKEN_OPERATOR, Value: value } as FILTER_TOKEN)
+    request[key] = tokenArray as T[keyof T]
+}
+
 export type DataAccessServiceParams<T> = {
     pagination?: {
         currentPageIndex: number,
@@ -228,12 +235,49 @@ export function useServersService(params: DataAccessServiceParams<Server>): Data
     };
 }
 
-export function useSessionTemplatesService(params: DataAccessServiceParams<SessionTemplate>): DataAccessServiceResult<SessionTemplate> {
+// Filter keys that need loginUsername → userId resolution
+const USER_FILTER_KEYS = ['UsersSharedWith', 'CreatedBy', 'LastModifiedBy']
+const USERS_SHARED_WITH_KEY = 'UsersSharedWith'
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+// Helper: Resolve user filter token to userIds
+const resolveUserFilter = async (token: PropertyFilterToken, dataService: DataAccessService): Promise<{ token: PropertyFilterToken, userIds: string[] }> => {
+    const isUUID = UUID_REGEX.test(token.value)
+    const isContains = token.operator === ':' || token.operator === '!:'
+    
+    // UUID from dropdown - use directly
+    if (isUUID && isContains) {
+        return { token, userIds: [token.value] }
+    }
+    
+    // CONTAINS - query backend for matching users
+    if (isContains) {
+        try {
+            const r = await dataService.describeUsers({ UserIds: [{ Operator: FilterTokenOperatorEnum.Contains, Value: token.value }] })
+            return { token, userIds: r.data.Users?.map(u => u.UserId).filter(Boolean) || [] }
+        } catch {
+            return { token, userIds: [] }
+        }
+    }
+    
+    // EQUAL/NOT_EQUAL - resolve single user
+    try {
+        const r = await dataService.describeUsers({ UserIds: [{ Operator: FilterTokenOperatorEnum.Equal, Value: token.value }] })
+        return { token, userIds: [r.data.Users?.[0]?.UserId || token.value] }
+    } catch {
+        return { token, userIds: [token.value] }
+    }
+}
+
+// Fetches session templates with user lookup: resolves loginUsername→userId for filtering,
+// then looks up userId→loginUsername for table display (CreatedBy/LastModifiedBy columns)
+export function useSessionTemplatesService(params: DataAccessServiceParams<SessionTemplate>): DataAccessServiceResult<SessionTemplate> & { userIdToLoginUsernameMap: Map<string, string> } {
     const {pageSize, currentPageIndex: clientPageIndex} = params.pagination || {};
     const {sortingDescending, sortingColumn} = params.sorting || {};
     const {filteringText, filteringTokens, filteringOperation} = params.filtering || {};
     const [loading, setLoading] = useState(true);
     const [items, setItems] = useState([] as SessionTemplate[]);
+    const [userIdToLoginUsernameMap, setUserIdToLoginUsernameMap] = useState(new Map<string, string>());
     const [totalCount, setTotalCount] = useState(0);
     const [currentPageIndex, setCurrentPageIndex] = useState(clientPageIndex as number);
     const [pagesCount, setPagesCount] = useState(0);
@@ -262,34 +306,81 @@ export function useSessionTemplatesService(params: DataAccessServiceParams<Sessi
             NextToken: params.pagination?.nextToken
         } as DescribeSessionTemplatesRequestData
 
+        const userFilterTokens: PropertyFilterToken[] = []
+
         params.filtering?.filteringTokens.forEach(token => {
             let key = token.propertyKey as keyof DescribeSessionTemplatesRequestData
             let operator: string = SPECIAL_OPERATORS.get(token.operator) || token.operator;
 
-            let tokenArray: Array<FILTER_TOKEN> = describeSessionTemplatesRequest[key] as Array<FILTER_TOKEN> || []
-            tokenArray.push({
-                Operator: operator as FILTER_TOKEN_OPERATOR,
-                Value: token.value
-            } as FILTER_TOKEN)
-            describeSessionTemplatesRequest[key] = tokenArray
+            if (USER_FILTER_KEYS.includes(token.propertyKey as string)) {
+                userFilterTokens.push(token)
+            } else {
+                addFilterToRequest(describeSessionTemplatesRequest, key, operator, token.value)
+            }
         })
 
-        console.log("describeSessionTemplatesRequest: ", describeSessionTemplatesRequest)
-        dataService.describeSessionTemplates(describeSessionTemplatesRequest)
-            .then(r => {
-                r.data.SessionTemplates
+        const resolveUserFilters = userFilterTokens.length > 0
+            ? Promise.all(userFilterTokens.map(token => resolveUserFilter(token, dataService)))
+            : Promise.resolve([])
+
+        resolveUserFilters
+            .then(resolvedTokens => {
+                // Send non-negated filters to backend
+                resolvedTokens
+                    .filter(({ token }) => token.operator !== '!:')
+                    .forEach(({ token, userIds }) => {
+                        const key = token.propertyKey as keyof DescribeSessionTemplatesRequestData
+                        const operator = SPECIAL_OPERATORS.get(token.operator) || token.operator
+                        userIds.forEach(userId => addFilterToRequest(describeSessionTemplatesRequest, key, operator, userId))
+                    })
+
+                return dataService.describeSessionTemplates(describeSessionTemplatesRequest)
+                    .then(r => ({ r, resolvedTokens }))
+            })
+            .then(({ r, resolvedTokens }) => {
+                // Client-side filter for NOT CONTAINS (backend OR logic doesn't support it)
+                let templates = r.data.SessionTemplates || []
+                resolvedTokens
+                    .filter(({ token }) => token.operator === '!:')
+                    .forEach(({ token, userIds }) => {
+                        const key = token.propertyKey as keyof SessionTemplate
+                        templates = templates.filter(t => !userIds.includes(t[key] as string))
+                    })
+                
+                // Collect userIds for display name lookup
+                const userIds = [...new Set([
+                    ...templates.flatMap(t => [t.CreatedBy, t.LastModifiedBy].filter(Boolean)),
+                    ...resolvedTokens.filter(({ token }) => token.operator === ':').flatMap(({ userIds }) => userIds)
+                ])] as string[]
+                
+                return dataService.describeUsersByIds(userIds).then(map => ({ templates, map, resolvedTokens }))
+            })
+            .then(({ templates, map, resolvedTokens }) => {
+                // Add EQUAL/NOT_EQUAL filter users to map
+                resolvedTokens
+                    .filter(({ token }) => token.operator === '=' || token.operator === '!=')
+                    .forEach(({ token, userIds }) => {
+                        if (token.propertyKey !== USERS_SHARED_WITH_KEY) {
+                            userIds.forEach(userId => {
+                                if (userId !== token.value) map.set(userId, token.value)
+                            })
+                        }
+                    })
+                
+                setUserIdToLoginUsernameMap(prev => new Map([...prev, ...map]))
+                setLoading(false)
+                setItems(templates)
+                setPagesCount(1)
+                setTotalCount(templates.length)
+                setNextToken(null)
+            })
+            .catch(e => {
+                console.error("Failed to retrieve sessionTemplates: ", e)
                 setLoading(false);
-                setItems(r.data.SessionTemplates || []);
+                setError(true);
+                setErrorMessage(e.message);
                 setPagesCount(1);
-                setTotalCount(r.data.SessionTemplates?.length || 0);
-                setNextToken(r.data.NextToken || null);
-            }).catch(e => {
-            console.error("Failed to retrieve sessionTemplates: ", e)
-            setLoading(false);
-            setError(true);
-            setErrorMessage(e.message);
-            setPagesCount(1);
-        });
+            })
     }, [
         currentPageIndex,
         refreshKey,
@@ -303,7 +394,8 @@ export function useSessionTemplatesService(params: DataAccessServiceParams<Sessi
         currentPageIndex,
         nextToken,
         error,
-        errorMessage
+        errorMessage,
+        userIdToLoginUsernameMap
     };
 
 }

--- a/dcv-access-console-web-client/server/src/components/common/hooks/DataAccessServiceHooks.ts
+++ b/dcv-access-console-web-client/server/src/components/common/hooks/DataAccessServiceHooks.ts
@@ -27,17 +27,11 @@ import DataAccessService from "@/components/common/utils/DataAccessService";
 import {TableProps} from "@cloudscape-design/components";
 import {SPECIAL_OPERATORS} from "@/components/common/utils/SearchUtils";
 import {PropertyFilterQuery, PropertyFilterToken} from "@cloudscape-design/collection-hooks";
+import {useSession} from "next-auth/react";
 
 export type FILTER_TOKEN = FilterToken | FilterStateToken | FilterDateToken
 export type FILTER_TOKEN_OPERATOR = FilterTokenOperatorEnum | FilterDateTokenOperatorEnum | FilterStateTokenOperatorEnum
 export const DEFAULT_FILTERING_QUERY = { tokens: [], operation: 'and' } as PropertyFilterQuery
-
-// Helper to add a filter token to a request object
-const addFilterToRequest = <T extends Record<string, any>>(request: T, key: keyof T, operator: string, value: string) => {
-    const tokenArray: Array<FILTER_TOKEN> = (request[key] as Array<FILTER_TOKEN>) || []
-    tokenArray.push({ Operator: operator as FILTER_TOKEN_OPERATOR, Value: value } as FILTER_TOKEN)
-    request[key] = tokenArray as T[keyof T]
-}
 
 export type DataAccessServiceParams<T> = {
     pagination?: {
@@ -235,43 +229,9 @@ export function useServersService(params: DataAccessServiceParams<Server>): Data
     };
 }
 
-// Filter keys that need loginUsername → userId resolution
-const USER_FILTER_KEYS = ['UsersSharedWith', 'CreatedBy', 'LastModifiedBy']
-const USERS_SHARED_WITH_KEY = 'UsersSharedWith'
-const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
-const NOT_CONTAINS_OPERATOR = '!:'
-const CONTAINS_OPERATOR = ':'
-const EQUAL_OPERATOR = '='
-const NOT_EQUAL_OPERATOR = '!='
-
-const resolveUserFilters = async (tokens: PropertyFilterToken[], dataService: DataAccessService) => {
-    if (tokens.length === 0) return []
-    
-    // UUIDs don't need resolution
-    const results = tokens.map(token => {
-        if (UUID_REGEX.test(token.value)) {
-            return Promise.resolve({ token, userIds: [token.value] })
-        }
-        
-        const isContains = SPECIAL_OPERATORS.has(token.operator)
-        const operator = isContains ? FilterTokenOperatorEnum.Contains : FilterTokenOperatorEnum.Equal
-        
-        return dataService.describeUsers({ UserIds: [{ Operator: operator, Value: token.value }] })
-            .then(r => {
-                const userIds = isContains
-                    ? r.data.Users?.map(u => u.UserId).filter(Boolean) || []
-                    : [r.data.Users?.[0]?.UserId || token.value]
-                return { token, userIds }
-            })
-            .catch(() => ({ token, userIds: isContains ? [] : [token.value] }))
-    })
-    
-    return Promise.all(results)
-}
-
-// Fetches session templates with user lookup: resolves loginUsername→userId for filtering,
-// then looks up userId→loginUsername for table display (CreatedBy/LastModifiedBy columns)
 export function useSessionTemplatesService(params: DataAccessServiceParams<SessionTemplate>): DataAccessServiceResult<SessionTemplate> & { userIdToLoginUsernameMap: Map<string, string> } {
+    const {data: session} = useSession()
+    const usingExternalAuth = session?.usingExternalAuth === true
     const {pageSize, currentPageIndex: clientPageIndex} = params.pagination || {};
     const {sortingDescending, sortingColumn} = params.sorting || {};
     const {filteringText, filteringTokens, filteringOperation} = params.filtering || {};
@@ -306,67 +266,42 @@ export function useSessionTemplatesService(params: DataAccessServiceParams<Sessi
             NextToken: params.pagination?.nextToken
         } as DescribeSessionTemplatesRequestData
 
-        const userFilterTokens: PropertyFilterToken[] = []
+        // Map user filter keys to backend LoginUsername filter keys for external auth
+        const loginUsernameFilterKeys: Record<string, string> = {
+            'CreatedBy': 'CreatedByLoginUsername',
+            'LastModifiedBy': 'LastModifiedByLoginUsername',
+            'UsersSharedWith': 'UsersSharedWithLoginUsername'
+        }
 
         params.filtering?.filteringTokens.forEach(token => {
             let key = token.propertyKey as keyof DescribeSessionTemplatesRequestData
             let operator: string = SPECIAL_OPERATORS.get(token.operator) || token.operator;
 
-            if (USER_FILTER_KEYS.includes(token.propertyKey as string)) {
-                userFilterTokens.push(token)
-            } else {
-                addFilterToRequest(describeSessionTemplatesRequest, key, operator, token.value)
+            const loginUsernameKey = loginUsernameFilterKeys[token.propertyKey as string]
+            if (loginUsernameKey && usingExternalAuth) {
+                key = loginUsernameKey as keyof DescribeSessionTemplatesRequestData
             }
+
+            let tokenArray: Array<FILTER_TOKEN> = describeSessionTemplatesRequest[key] as Array<FILTER_TOKEN> || []
+            tokenArray.push({
+                Operator: operator as FILTER_TOKEN_OPERATOR,
+                Value: token.value
+            } as FILTER_TOKEN)
+            describeSessionTemplatesRequest[key] = tokenArray
         })
 
-        resolveUserFilters(userFilterTokens, dataService)
-            .then(resolvedTokens => {
-                // NOT_CONTAINS handled client-side because backend ORs multiple filters:
-                // Example: "admin" matches admin2 (uuid1) and admin5 (uuid2)
-                //   Backend: (CreatedBy !: uuid1) OR (CreatedBy !: uuid2)
-                //   Template by uuid1: (!: uuid1=false) OR (!: uuid2=true) = TRUE (kept incorrectly!)
-                //   Need: (CreatedBy !: uuid1) AND (CreatedBy !: uuid2) → client-side filtering
-                resolvedTokens
-                    .filter(({ token }) => token.operator !== NOT_CONTAINS_OPERATOR)
-                    .forEach(({ token, userIds }) => {
-                        const key = token.propertyKey as keyof DescribeSessionTemplatesRequestData
-                        const operator = SPECIAL_OPERATORS.get(token.operator) || token.operator
-                        userIds.forEach(userId => addFilterToRequest(describeSessionTemplatesRequest, key, operator, userId))
-                    })
-
-                return dataService.describeSessionTemplates(describeSessionTemplatesRequest)
-                    .then(r => ({ r, resolvedTokens }))
+        dataService.describeSessionTemplates(describeSessionTemplatesRequest)
+            .then(r => {
+                const templates = r.data.SessionTemplates || []
+                if (usingExternalAuth) {
+                    const userIds = [...new Set(
+                        templates.flatMap(t => [t.CreatedBy, t.LastModifiedBy].filter(Boolean))
+                    )] as string[]
+                    return dataService.describeUsersByIds(userIds).then(map => ({ templates, map }))
+                }
+                return { templates, map: new Map<string, string>() }
             })
-            .then(({ r, resolvedTokens }) => {
-                // Client-side NOT_CONTAINS filtering (see comment above for why)
-                let templates = r.data.SessionTemplates || []
-                resolvedTokens
-                    .filter(({ token }) => token.operator === NOT_CONTAINS_OPERATOR)
-                    .forEach(({ token, userIds }) => {
-                        const key = token.propertyKey as keyof SessionTemplate
-                        templates = templates.filter(t => !userIds.includes(t[key] as string))
-                    })
-                
-                // Collect userIds for display name lookup
-                const userIds = [...new Set([
-                    ...templates.flatMap(t => [t.CreatedBy, t.LastModifiedBy].filter(Boolean)),
-                    ...resolvedTokens.filter(({ token }) => token.operator === CONTAINS_OPERATOR).flatMap(({ userIds }) => userIds)
-                ])] as string[]
-                
-                return dataService.describeUsersByIds(userIds).then(map => ({ templates, map, resolvedTokens }))
-            })
-            .then(({ templates, map, resolvedTokens }) => {
-                // Add EQUAL/NOT_EQUAL filter users to map
-                resolvedTokens
-                    .filter(({ token }) => token.operator === EQUAL_OPERATOR || token.operator === NOT_EQUAL_OPERATOR)
-                    .forEach(({ token, userIds }) => {
-                        if (token.propertyKey !== USERS_SHARED_WITH_KEY) {
-                            userIds.forEach(userId => {
-                                if (userId !== token.value) map.set(userId, token.value)
-                            })
-                        }
-                    })
-                
+            .then(({ templates, map }) => {
                 setUserIdToLoginUsernameMap(prev => new Map([...prev, ...map]))
                 setLoading(false)
                 setItems(templates)

--- a/dcv-access-console-web-client/server/src/components/common/hooks/DataAccessServiceHooks.ts
+++ b/dcv-access-console-web-client/server/src/components/common/hooks/DataAccessServiceHooks.ts
@@ -229,7 +229,7 @@ export function useServersService(params: DataAccessServiceParams<Server>): Data
     };
 }
 
-export function useSessionTemplatesService(params: DataAccessServiceParams<SessionTemplate>): DataAccessServiceResult<SessionTemplate> & { userIdToLoginUsernameMap: Map<string, string> } {
+export function useSessionTemplatesService(params: DataAccessServiceParams<SessionTemplate>): DataAccessServiceResult<SessionTemplate> {
     const {data: session} = useSession()
     const usingExternalAuth = session?.usingExternalAuth === true
     const {pageSize, currentPageIndex: clientPageIndex} = params.pagination || {};
@@ -237,7 +237,6 @@ export function useSessionTemplatesService(params: DataAccessServiceParams<Sessi
     const {filteringText, filteringTokens, filteringOperation} = params.filtering || {};
     const [loading, setLoading] = useState(true);
     const [items, setItems] = useState([] as SessionTemplate[]);
-    const [userIdToLoginUsernameMap, setUserIdToLoginUsernameMap] = useState(new Map<string, string>());
     const [totalCount, setTotalCount] = useState(0);
     const [currentPageIndex, setCurrentPageIndex] = useState(clientPageIndex as number);
     const [pagesCount, setPagesCount] = useState(0);
@@ -291,18 +290,11 @@ export function useSessionTemplatesService(params: DataAccessServiceParams<Sessi
         })
 
         dataService.describeSessionTemplates(describeSessionTemplatesRequest)
-            .then(r => {
+            .then(async r => {
                 const templates = r.data.SessionTemplates || []
                 if (usingExternalAuth) {
-                    const userIds = [...new Set(
-                        templates.flatMap(t => [t.CreatedBy, t.LastModifiedBy].filter(Boolean))
-                    )] as string[]
-                    return dataService.describeUsersByIds(userIds).then(map => ({ templates, map }))
+                    await dataService.replaceUserIdsWithLoginUsernames(templates)
                 }
-                return { templates, map: new Map<string, string>() }
-            })
-            .then(({ templates, map }) => {
-                setUserIdToLoginUsernameMap(prev => new Map([...prev, ...map]))
                 setLoading(false)
                 setItems(templates)
                 setPagesCount(1)
@@ -329,10 +321,8 @@ export function useSessionTemplatesService(params: DataAccessServiceParams<Sessi
         currentPageIndex,
         nextToken,
         error,
-        errorMessage,
-        userIdToLoginUsernameMap
+        errorMessage
     };
-
 }
 
 export function useUsersService(params: DataAccessServiceParams<User>): DataAccessServiceResult<User> {

--- a/dcv-access-console-web-client/server/src/components/common/table-with-pagination/TableWithPagination.tsx
+++ b/dcv-access-console-web-client/server/src/components/common/table-with-pagination/TableWithPagination.tsx
@@ -27,6 +27,7 @@ export type TableWithPaginationProps<T> = {
     customPreference?: (value: string, setValue: (value: string) => void) => JSX.Element
     setView?: (view : string) => void
     contentDisplayOptions:  readonly CollectionPreferencesProps.ContentDisplayOption[]
+    onUserMapChange?: (map: Map<string, string>) => void
 }
 
 export default function TableWithPagination<T>(
@@ -46,7 +47,8 @@ export default function TableWithPagination<T>(
         customPageSizePreferences,
         customPreference,
         setView,
-        contentDisplayOptions
+        contentDisplayOptions,
+        onUserMapChange
     }: TableWithPaginationProps<T>) {
 
     const [currentPageIndex, setCurrentPageIndex] = useState(1)
@@ -79,6 +81,14 @@ export default function TableWithPagination<T>(
     }
 
     const result: DataAccessServiceResult<T> = dataAccessServiceFunction(params);
+
+    // Forward userIdToLoginUsernameMap from hook to parent (only useSessionTemplatesService returns this)
+    useEffect(() => {
+        const resultWithMap = result as DataAccessServiceResult<T> & { userIdToLoginUsernameMap?: Map<string, string> }
+        if (onUserMapChange && resultWithMap.userIdToLoginUsernameMap) {
+            onUserMapChange(resultWithMap.userIdToLoginUsernameMap)
+        }
+    }, [(result as any).userIdToLoginUsernameMap])
 
     useEffect(() => {
         // Check if this page has no items
@@ -140,6 +150,10 @@ export default function TableWithPagination<T>(
     useEffect(() => {
         resetPagination();
     }, [preferences.pageSize, resetPaginationKey])
+
+    useEffect(() => {
+        resetPagination();
+    }, [sortingColumn, sortingDescending])
 
     const handleSortingChange = event => {
         setSortingDescending(event.detail.isDescending)

--- a/dcv-access-console-web-client/server/src/components/common/table-with-pagination/TableWithPagination.tsx
+++ b/dcv-access-console-web-client/server/src/components/common/table-with-pagination/TableWithPagination.tsx
@@ -27,7 +27,6 @@ export type TableWithPaginationProps<T> = {
     customPreference?: (value: string, setValue: (value: string) => void) => JSX.Element
     setView?: (view : string) => void
     contentDisplayOptions:  readonly CollectionPreferencesProps.ContentDisplayOption[]
-    onUserMapChange?: (map: Map<string, string>) => void
 }
 
 export default function TableWithPagination<T>(
@@ -47,8 +46,7 @@ export default function TableWithPagination<T>(
         customPageSizePreferences,
         customPreference,
         setView,
-        contentDisplayOptions,
-        onUserMapChange
+        contentDisplayOptions
     }: TableWithPaginationProps<T>) {
 
     const [currentPageIndex, setCurrentPageIndex] = useState(1)
@@ -81,14 +79,6 @@ export default function TableWithPagination<T>(
     }
 
     const result: DataAccessServiceResult<T> = dataAccessServiceFunction(params);
-
-    // Forward userIdToLoginUsernameMap from hook to parent (only useSessionTemplatesService returns this)
-    useEffect(() => {
-        const resultWithMap = result as DataAccessServiceResult<T> & { userIdToLoginUsernameMap?: Map<string, string> }
-        if (onUserMapChange && resultWithMap.userIdToLoginUsernameMap) {
-            onUserMapChange(resultWithMap.userIdToLoginUsernameMap)
-        }
-    }, [(result as any).userIdToLoginUsernameMap])
 
     useEffect(() => {
         // Check if this page has no items

--- a/dcv-access-console-web-client/server/src/components/common/utils/DataAccessService.ts
+++ b/dcv-access-console-web-client/server/src/components/common/utils/DataAccessService.ts
@@ -18,7 +18,7 @@ import {
     DescribeUsersRequestData,
     DescribeUsersSharedWithSessionTemplateRequestData, DescribeUsersSharedWithSessionTemplateResponse,
     EditSessionTemplateRequestData,
-    EditUserGroupRequestData, GetSessionConnectionDataUIResponse,
+    EditUserGroupRequestData, FilterTokenOperatorEnum, GetSessionConnectionDataUIResponse,
     GetSessionScreenshotsUIRequestData,
     PublishSessionTemplateRequestData,
     RemoveFromUserGroupRequestData,
@@ -85,6 +85,21 @@ export default class DataAccessService {
     }
     public async describeUsers(describeUsersRequest?: DescribeUsersRequestData) {
         return (await this.getUsersApi()).describeUsers(describeUsersRequest)
+    }
+
+    public async describeUsersByIds(userIds: string[]): Promise<Map<string, string>> {
+        const map = new Map<string, string>()
+        if (userIds.length === 0) return map
+        
+        const filters = userIds.map(id => ({ Operator: FilterTokenOperatorEnum.Equal, Value: id }))
+        const response = await this.describeUsers({ InternalUserIds: filters })
+        
+        response.data.Users?.forEach(user => {
+            if (user.UserId) {
+                map.set(user.UserId, user.LoginUsername || user.UserId)
+            }
+        })
+        return map
     }
 
     public async createSessionTemplate(createSessionTemplateRequest?: CreateSessionTemplateRequestData) {

--- a/dcv-access-console-web-client/server/src/components/common/utils/DataAccessService.ts
+++ b/dcv-access-console-web-client/server/src/components/common/utils/DataAccessService.ts
@@ -92,7 +92,7 @@ export default class DataAccessService {
         if (userIds.length === 0) return map
         
         const filters = userIds.map(id => ({ Operator: FilterTokenOperatorEnum.Equal, Value: id }))
-        const response = await this.describeUsers({ InternalUserIds: filters })
+        const response = await this.describeUsers({ UserIds: filters })
         
         response.data.Users?.forEach(user => {
             if (user.UserId) {

--- a/dcv-access-console-web-client/server/src/components/common/utils/DataAccessService.ts
+++ b/dcv-access-console-web-client/server/src/components/common/utils/DataAccessService.ts
@@ -25,6 +25,7 @@ import {
     ServersApi,
     SessionsApi,
     SessionScreenshotImage,
+    SessionTemplate,
     SessionTemplatesApi,
     SessionWithPermissions,
     UnpublishSessionTemplateRequestData,
@@ -100,6 +101,21 @@ export default class DataAccessService {
             }
         })
         return map
+    }
+
+    /**
+     * Replaces CreatedBy and LastModifiedBy user IDs with login usernames for display.
+     * Only call this when using external auth. Falls back to user ID if username not found.
+     */
+    public async replaceUserIdsWithLoginUsernames(templates: SessionTemplate[]): Promise<void> {
+        const userIds = [...new Set(
+            templates.flatMap(t => [t.CreatedBy, t.LastModifiedBy].filter(Boolean))
+        )] as string[]
+        const map = await this.describeUsersByIds(userIds)
+        templates.forEach(t => {
+            if (t.CreatedBy) t.CreatedBy = map.get(t.CreatedBy) || t.CreatedBy
+            if (t.LastModifiedBy) t.LastModifiedBy = map.get(t.LastModifiedBy) || t.LastModifiedBy
+        })
     }
 
     public async createSessionTemplate(createSessionTemplateRequest?: CreateSessionTemplateRequestData) {

--- a/dcv-access-console-web-client/server/src/components/common/utils/SearchUtils.tsx
+++ b/dcv-access-console-web-client/server/src/components/common/utils/SearchUtils.tsx
@@ -130,6 +130,12 @@ export const getFieldValues = (object: any, fieldName: string | string[]): strin
         const list = reduceFieldValues(object, fieldName[0]) as []
         return list.map(item => {return reduceFieldValues(item, fieldName[1])})
     }
+    if (fieldName === 'LoginUsername') {
+        const loginUsername = reduceFieldValues(object, 'LoginUsername')
+        if (loginUsername != null) return [loginUsername]
+        const userId = reduceFieldValues(object, 'UserId')
+        return userId != null ? [userId] : []
+    }
     return [reduceFieldValues(object, fieldName as string)]
 }
 

--- a/dcv-access-console-web-client/server/src/components/session-templates/assign-users-groups/AssignUsersGroups.tsx
+++ b/dcv-access-console-web-client/server/src/components/session-templates/assign-users-groups/AssignUsersGroups.tsx
@@ -174,7 +174,7 @@ export default function AssignUsersGroups({
                 Value: filterString
             } as FilterToken],
             SortToken: {
-                Operator: "DESC",
+                Operator: "ASC",
                 Key: "UserId"
             },
             NextToken: nextToken,

--- a/dcv-access-console-web-client/server/src/components/session-templates/assign-users-groups/AssignUsersGroups.tsx
+++ b/dcv-access-console-web-client/server/src/components/session-templates/assign-users-groups/AssignUsersGroups.tsx
@@ -169,7 +169,7 @@ export default function AssignUsersGroups({
 
     const getFilteredUsers = async (filterString: string, nextToken?: string | null) => {
         const describeUsersRequest: DescribeUsersRequestData = {
-            UserIds: [{
+            LoginUsernames: [{
                 Operator: "CONTAINS",
                 Value: filterString
             } as FilterToken],

--- a/dcv-access-console-web-client/server/src/components/session-templates/create-wizard/SessionTemplatesCreateWizard.tsx
+++ b/dcv-access-console-web-client/server/src/components/session-templates/create-wizard/SessionTemplatesCreateWizard.tsx
@@ -427,6 +427,7 @@ export default function SessionTemplatesCreateWizard({infoLinkFollow, isEditWiza
     const [errorName, setErrorName] = useState()
     const [errorRequirements, setErrorRequirements] = useState()
     const [users, setUsers] = React.useState([null])
+    const [userLabels, setUserLabels] = React.useState<string[]>([])
     const [groups, setGroups] = React.useState([null])
     const [isAwsServerAvailable, setIsAwsServerAvailable] = React.useState(false)
     const {items, addFlashBar} = useFlashBarContext()
@@ -781,12 +782,15 @@ export default function SessionTemplatesCreateWizard({infoLinkFollow, isEditWiza
                         sessionTemplateId={existingSessionTemplateId!}
                         handleUsersChange={(users: [OptionDefinition]) => {
                             let userIds: [string] = []
+                            let labels: string[] = []
                             users.forEach(user => {
                                 if (user.value != null) {
                                     userIds.push(user.value)
+                                    labels.push(user.label || user.value)
                                 }
                             })
                             setUsers(userIds)
+                            setUserLabels(labels)
                         }}
                         handleGroupsChange={(groups: [OptionDefinition]) => {
                             let groupIds: [string] = []
@@ -906,7 +910,7 @@ export default function SessionTemplatesCreateWizard({infoLinkFollow, isEditWiza
                                         >
                                             <SpaceBetween size="s">
                                                 <ValueWithLabel label={SESSION_TEMPLATES_CREATE_CONSTANTS.USERS}>
-                                                    {getCleanArray(users).join(', ') || "Not specified"}
+                                                    {getCleanArray(userLabels).join(', ') || "Not specified"}
                                                 </ValueWithLabel>
                                             </SpaceBetween>
                                             <SpaceBetween size="s">

--- a/dcv-access-console-web-client/server/src/components/session-templates/session-template-details/SessionTemplateDetails.tsx
+++ b/dcv-access-console-web-client/server/src/components/session-templates/session-template-details/SessionTemplateDetails.tsx
@@ -49,7 +49,6 @@ export default function SessionTemplateDetails(props: SessionTemplateDetailsProp
         error: false
     })
 
-    const [userDisplayNames, setUserDisplayNames] = useState<Map<string, string>>(new Map())
     const [refreshKey, setRefreshKey] = useState("")
     const [resetPaginationKey, setResetPaginationKey] = useState("")
     const [modalVisible, setModalVisible] = useState<boolean>(false)
@@ -141,10 +140,6 @@ export default function SessionTemplateDetails(props: SessionTemplateDetailsProp
         if (props.sessionTemplate) {
             getUsersForSessionTemplate(props.sessionTemplate)
             getGroupsForSessionTemplate(props.sessionTemplate)
-            const userIds = [props.sessionTemplate.CreatedBy, props.sessionTemplate.LastModifiedBy].filter(Boolean) as string[]
-            if (userIds.length > 0) {
-                dataAccessService.describeUsersByIds(userIds).then(setUserDisplayNames)
-            }
         }
         setResetPaginationKey(Date.now().toString())
     }, [props.sessionTemplate])
@@ -213,7 +208,7 @@ export default function SessionTemplateDetails(props: SessionTemplateDetailsProp
                 header={<HeaderWithCounter actions={actionsButton()}>{getValueOrUnknown(props.sessionTemplate?.Name)}</HeaderWithCounter>}
             >
                 <SpaceBetween size={"l"}>
-                    <SessionTemplateOverview sessionTemplate={props.sessionTemplate!} userDisplayNames={userDisplayNames}/>
+                    <SessionTemplateOverview sessionTemplate={props.sessionTemplate!}/>
                     <UsersTab users={usersState.users || []} sessionTemplateId={props.sessionTemplate?.Id}/>
                     <GroupsTab groups={userGroupsState.groups || []} sessionTemplateId={props.sessionTemplate?.Id}/>
                 </SpaceBetween>

--- a/dcv-access-console-web-client/server/src/components/session-templates/session-template-details/SessionTemplateDetails.tsx
+++ b/dcv-access-console-web-client/server/src/components/session-templates/session-template-details/SessionTemplateDetails.tsx
@@ -49,6 +49,7 @@ export default function SessionTemplateDetails(props: SessionTemplateDetailsProp
         error: false
     })
 
+    const [userDisplayNames, setUserDisplayNames] = useState<Map<string, string>>(new Map())
     const [refreshKey, setRefreshKey] = useState("")
     const [resetPaginationKey, setResetPaginationKey] = useState("")
     const [modalVisible, setModalVisible] = useState<boolean>(false)
@@ -140,6 +141,10 @@ export default function SessionTemplateDetails(props: SessionTemplateDetailsProp
         if (props.sessionTemplate) {
             getUsersForSessionTemplate(props.sessionTemplate)
             getGroupsForSessionTemplate(props.sessionTemplate)
+            const userIds = [props.sessionTemplate.CreatedBy, props.sessionTemplate.LastModifiedBy].filter(Boolean) as string[]
+            if (userIds.length > 0) {
+                dataAccessService.describeUsersByIds(userIds).then(setUserDisplayNames)
+            }
         }
         setResetPaginationKey(Date.now().toString())
     }, [props.sessionTemplate])
@@ -208,7 +213,7 @@ export default function SessionTemplateDetails(props: SessionTemplateDetailsProp
                 header={<HeaderWithCounter actions={actionsButton()}>{getValueOrUnknown(props.sessionTemplate?.Name)}</HeaderWithCounter>}
             >
                 <SpaceBetween size={"l"}>
-                    <SessionTemplateOverview sessionTemplate={props.sessionTemplate!}/>
+                    <SessionTemplateOverview sessionTemplate={props.sessionTemplate!} userDisplayNames={userDisplayNames}/>
                     <UsersTab users={usersState.users || []} sessionTemplateId={props.sessionTemplate?.Id}/>
                     <GroupsTab groups={userGroupsState.groups || []} sessionTemplateId={props.sessionTemplate?.Id}/>
                 </SpaceBetween>

--- a/dcv-access-console-web-client/server/src/components/session-templates/session-template-overview/SessionTemplateOverview.tsx
+++ b/dcv-access-console-web-client/server/src/components/session-templates/session-template-overview/SessionTemplateOverview.tsx
@@ -12,7 +12,12 @@ import OsLabel from "@/components/session-templates/os-label/OsLabel";
 import {SESSION_TEMPLATES_CREATE_CONSTANTS} from "@/constants/session-templates-create-constants";
 import {SESSION_TEMPLATES_TABLE_CONSTANTS} from "@/constants/session-templates-table-constants";
 
-export default function SessionTemplateOverview({sessionTemplate}: { sessionTemplate: SessionTemplate | undefined }) {
+type Props = {
+    sessionTemplate: SessionTemplate | undefined
+    userDisplayNames?: Map<string, string>
+}
+
+export default function SessionTemplateOverview({sessionTemplate, userDisplayNames = new Map()}: Props) {
     if (!sessionTemplate) {
         return <Box textAlign="center">{SESSION_TEMPLATES_DETAILS_CONSTANTS.EMPTY_TEXT}</Box>;
     }
@@ -36,11 +41,11 @@ export default function SessionTemplateOverview({sessionTemplate}: { sessionTemp
                     <ValueWithLabel
                         label={SESSION_TEMPLATES_TABLE_CONSTANTS.CREATION_TIME_HEADER}>{formatDate(sessionTemplate?.CreationTime)}</ValueWithLabel>
                     <ValueWithLabel
-                        label={SESSION_TEMPLATES_TABLE_CONSTANTS.CREATED_BY_HEADER}>{sessionTemplate?.CreatedBy}</ValueWithLabel>
+                        label={SESSION_TEMPLATES_TABLE_CONSTANTS.CREATED_BY_HEADER}>{userDisplayNames.get(sessionTemplate?.CreatedBy) || sessionTemplate?.CreatedBy}</ValueWithLabel>
                     <ValueWithLabel
                         label={SESSION_TEMPLATES_TABLE_CONSTANTS.LAST_MODIFIED_TIME_HEADER}>{formatDate(sessionTemplate?.LastModifiedTime)}</ValueWithLabel>
                     <ValueWithLabel
-                        label={SESSION_TEMPLATES_TABLE_CONSTANTS.LAST_MODIFIED_BY_HEADER}>{sessionTemplate?.LastModifiedBy}</ValueWithLabel>
+                        label={SESSION_TEMPLATES_TABLE_CONSTANTS.LAST_MODIFIED_BY_HEADER}>{userDisplayNames.get(sessionTemplate?.LastModifiedBy) || sessionTemplate?.LastModifiedBy}</ValueWithLabel>
                 </SpaceBetween>
                 <SpaceBetween size="l">
                     <ValueWithLabel

--- a/dcv-access-console-web-client/server/src/components/session-templates/session-template-overview/SessionTemplateOverview.tsx
+++ b/dcv-access-console-web-client/server/src/components/session-templates/session-template-overview/SessionTemplateOverview.tsx
@@ -14,10 +14,9 @@ import {SESSION_TEMPLATES_TABLE_CONSTANTS} from "@/constants/session-templates-t
 
 type Props = {
     sessionTemplate: SessionTemplate | undefined
-    userDisplayNames?: Map<string, string>
 }
 
-export default function SessionTemplateOverview({sessionTemplate, userDisplayNames = new Map()}: Props) {
+export default function SessionTemplateOverview({sessionTemplate}: Props) {
     if (!sessionTemplate) {
         return <Box textAlign="center">{SESSION_TEMPLATES_DETAILS_CONSTANTS.EMPTY_TEXT}</Box>;
     }
@@ -41,11 +40,11 @@ export default function SessionTemplateOverview({sessionTemplate, userDisplayNam
                     <ValueWithLabel
                         label={SESSION_TEMPLATES_TABLE_CONSTANTS.CREATION_TIME_HEADER}>{formatDate(sessionTemplate?.CreationTime)}</ValueWithLabel>
                     <ValueWithLabel
-                        label={SESSION_TEMPLATES_TABLE_CONSTANTS.CREATED_BY_HEADER}>{userDisplayNames.get(sessionTemplate?.CreatedBy) || sessionTemplate?.CreatedBy}</ValueWithLabel>
+                        label={SESSION_TEMPLATES_TABLE_CONSTANTS.CREATED_BY_HEADER}>{sessionTemplate?.CreatedBy}</ValueWithLabel>
                     <ValueWithLabel
                         label={SESSION_TEMPLATES_TABLE_CONSTANTS.LAST_MODIFIED_TIME_HEADER}>{formatDate(sessionTemplate?.LastModifiedTime)}</ValueWithLabel>
                     <ValueWithLabel
-                        label={SESSION_TEMPLATES_TABLE_CONSTANTS.LAST_MODIFIED_BY_HEADER}>{userDisplayNames.get(sessionTemplate?.LastModifiedBy) || sessionTemplate?.LastModifiedBy}</ValueWithLabel>
+                        label={SESSION_TEMPLATES_TABLE_CONSTANTS.LAST_MODIFIED_BY_HEADER}>{sessionTemplate?.LastModifiedBy}</ValueWithLabel>
                 </SpaceBetween>
                 <SpaceBetween size="l">
                     <ValueWithLabel

--- a/dcv-access-console-web-client/server/src/components/session-templates/session-templates-details-tabs/SessionTemplatesDetailsTabs.tsx
+++ b/dcv-access-console-web-client/server/src/components/session-templates/session-templates-details-tabs/SessionTemplatesDetailsTabs.tsx
@@ -37,7 +37,7 @@ export function SessionTemplatesDetailsTabs(props: SessionTemplatesDetailsTabsPr
         error: false
     })
 
-    const [userDisplayNames, setUserDisplayNames] = useState<Map<string, string>>(new Map())
+
 
     const getUsersForSessionTemplate = (sessionTemplate: SessionTemplate) => {
         // TODO: Paginate
@@ -104,10 +104,6 @@ export function SessionTemplatesDetailsTabs(props: SessionTemplatesDetailsTabsPr
         if (props.sessionTemplate) {
             getUsersForSessionTemplate(props.sessionTemplate)
             getGroupsForSessionTemplate(props.sessionTemplate)
-            const userIds = [props.sessionTemplate.CreatedBy, props.sessionTemplate.LastModifiedBy].filter(Boolean) as string[]
-            if (userIds.length > 0) {
-                dataAccessService.describeUsersByIds(userIds).then(setUserDisplayNames)
-            }
         }
     }, [props.sessionTemplate])
 
@@ -116,7 +112,7 @@ export function SessionTemplatesDetailsTabs(props: SessionTemplatesDetailsTabsPr
             {
                 label: SESSION_TEMPLATES_DETAILS_CONSTANTS.DETAILS,
                 id: "details",
-                content: <SessionTemplateOverview sessionTemplate={sessionTemplate} userDisplayNames={userDisplayNames}/>
+                content: <SessionTemplateOverview sessionTemplate={sessionTemplate}/>
             },
             {
                 label: SESSION_TEMPLATES_DETAILS_CONSTANTS.USERS,

--- a/dcv-access-console-web-client/server/src/components/session-templates/session-templates-details-tabs/SessionTemplatesDetailsTabs.tsx
+++ b/dcv-access-console-web-client/server/src/components/session-templates/session-templates-details-tabs/SessionTemplatesDetailsTabs.tsx
@@ -37,6 +37,8 @@ export function SessionTemplatesDetailsTabs(props: SessionTemplatesDetailsTabsPr
         error: false
     })
 
+    const [userDisplayNames, setUserDisplayNames] = useState<Map<string, string>>(new Map())
+
     const getUsersForSessionTemplate = (sessionTemplate: SessionTemplate) => {
         // TODO: Paginate
         const describeUsersSharedWithSessionTemplateRequest: DescribeUsersSharedWithSessionTemplateRequestData = {
@@ -102,6 +104,10 @@ export function SessionTemplatesDetailsTabs(props: SessionTemplatesDetailsTabsPr
         if (props.sessionTemplate) {
             getUsersForSessionTemplate(props.sessionTemplate)
             getGroupsForSessionTemplate(props.sessionTemplate)
+            const userIds = [props.sessionTemplate.CreatedBy, props.sessionTemplate.LastModifiedBy].filter(Boolean) as string[]
+            if (userIds.length > 0) {
+                dataAccessService.describeUsersByIds(userIds).then(setUserDisplayNames)
+            }
         }
     }, [props.sessionTemplate])
 
@@ -110,7 +116,7 @@ export function SessionTemplatesDetailsTabs(props: SessionTemplatesDetailsTabsPr
             {
                 label: SESSION_TEMPLATES_DETAILS_CONSTANTS.DETAILS,
                 id: "details",
-                content: <SessionTemplateOverview sessionTemplate={sessionTemplate}/>
+                content: <SessionTemplateOverview sessionTemplate={sessionTemplate} userDisplayNames={userDisplayNames}/>
             },
             {
                 label: SESSION_TEMPLATES_DETAILS_CONSTANTS.USERS,

--- a/dcv-access-console-web-client/server/src/components/session-templates/session-templates-table/SessionTemplatesTable.tsx
+++ b/dcv-access-console-web-client/server/src/components/session-templates/session-templates-table/SessionTemplatesTable.tsx
@@ -40,11 +40,12 @@ import DeleteSessionTemplateModal, {
 import {CancelableEventHandler} from "@cloudscape-design/components/internal/events";
 import {LinkProps} from "@cloudscape-design/components/link/interfaces";
 import TableWithPagination from "@/components/common/table-with-pagination/TableWithPagination";
-import FilterBar, {DescribeResponse, ValueToLabelMap} from "@/components/common/filter-bar/FilterBar";
+import FilterBar, {DescribeResponse} from "@/components/common/filter-bar/FilterBar";
 import session_template_search_tokens from "@/generated-src/client/session_template_search_tokens";
 import {PropertyFilterQuery} from "@cloudscape-design/collection-hooks";
 
-export type UserIdToLoginUsernameMap = Map<string, string>;
+import {useSession} from "next-auth/react";
+
 export default function SessionTemplatesTable({   selectedSessionTemplates,
                                                   setSelectedSessionTemplates,
                                                   addHeader,
@@ -75,20 +76,20 @@ export default function SessionTemplatesTable({   selectedSessionTemplates,
     const [modalVisible, setModalVisible] = useState<boolean>(false);
     const [deleteSessionTemplateProps, setDeleteSessionTemplateProps] = useState<DeleteSessionTemplateProps>()
     const [resetPaginationKey, setResetPaginationKey] = useState("")
-    const [userIdToLoginUsernameMap, setUserIdToLoginUsernameMap] = useState<UserIdToLoginUsernameMap>(new Map())
     const {push} = useRouter()
     const {addFlashBar} = useFlashBarContext()
     const dataAccessService = new DataAccessService()
+    const {data: session} = useSession()
+    const usingExternalAuth = session?.usingExternalAuth === true
 
     const describeSessionTemplates = async (describeSessionTemplatesRequest: DescribeSessionTemplatesRequestData) => {
         const r = await dataAccessService.describeSessionTemplates(describeSessionTemplatesRequest)
-        return {"objects": r.data.SessionTemplates, "nextToken": r.data.NextToken} as DescribeResponse
+        const templates = r.data.SessionTemplates || []
+        if (usingExternalAuth) {
+            await dataAccessService.replaceUserIdsWithLoginUsernames(templates)
+        }
+        return {"objects": templates, "nextToken": r.data.NextToken} as DescribeResponse
     }
-
-    const propertyValueToLabelMaps = new Map<string, ValueToLabelMap>([
-        ["CreatedBy", userIdToLoginUsernameMap],
-        ["LastModifiedBy", userIdToLoginUsernameMap]
-    ])
 
     const filter = <FilterBar
         filteringQuery={query}
@@ -101,8 +102,7 @@ export default function SessionTemplatesTable({   selectedSessionTemplates,
         tokenNameGroupMap={TOKEN_NAME_GROUP_MAP}
         searchTokenToId={SEARCH_TOKEN_TO_ID}
         filteringPlaceholder={FILTER_SESSION_TEMPLATES_CONSTANTS.filteringPlaceholder}
-        dataAccessServiceFunction={describeSessionTemplates}
-        propertyValueToLabelMaps={propertyValueToLabelMaps}/>
+        dataAccessServiceFunction={describeSessionTemplates}/>
 
     const viewUserDetailsButton = () => {
         return <Button variant="normal" disabled={selectedSessionTemplates?.length != 1}
@@ -224,7 +224,7 @@ export default function SessionTemplatesTable({   selectedSessionTemplates,
         }
     }
 
-    const columnDefinitions = getSessionTemplatesTableColumnDefinitions(userIdToLoginUsernameMap)
+    const columnDefinitions = getSessionTemplatesTableColumnDefinitions()
 
     const table = <Table
         variant={variant}
@@ -272,7 +272,6 @@ export default function SessionTemplatesTable({   selectedSessionTemplates,
                 deleteItemsKey={deleteItemsKey}
                 resetPaginationKey={resetPaginationKey}
                 contentDisplayOptions={CONTENT_DISPLAY_OPTIONS}
-                onUserMapChange={setUserIdToLoginUsernameMap}
             />
             <DeleteSessionTemplateModal visible={modalVisible} setVisible={setModalVisible}
                                         deleteSessionTemplateProps={deleteSessionTemplateProps!}

--- a/dcv-access-console-web-client/server/src/components/session-templates/session-templates-table/SessionTemplatesTable.tsx
+++ b/dcv-access-console-web-client/server/src/components/session-templates/session-templates-table/SessionTemplatesTable.tsx
@@ -6,7 +6,7 @@ import {useState} from "react";
 import Table from "@cloudscape-design/components/table";
 import Box from "@cloudscape-design/components/box";
 import {
-    SESSION_TEMPLATES_TABLE_COLUMN_DEFINITIONS,
+    getSessionTemplatesTableColumnDefinitions,
 } from "@/components/session-templates/session-templates-table/SessionTemplatesTableColumnDefinitions";
 import {
     CONTENT_DISPLAY_OPTIONS
@@ -40,10 +40,11 @@ import DeleteSessionTemplateModal, {
 import {CancelableEventHandler} from "@cloudscape-design/components/internal/events";
 import {LinkProps} from "@cloudscape-design/components/link/interfaces";
 import TableWithPagination from "@/components/common/table-with-pagination/TableWithPagination";
-import FilterBar, {DescribeResponse} from "@/components/common/filter-bar/FilterBar";
+import FilterBar, {DescribeResponse, ValueToLabelMap} from "@/components/common/filter-bar/FilterBar";
 import session_template_search_tokens from "@/generated-src/client/session_template_search_tokens";
 import {PropertyFilterQuery} from "@cloudscape-design/collection-hooks";
 
+export type UserIdToLoginUsernameMap = Map<string, string>;
 export default function SessionTemplatesTable({   selectedSessionTemplates,
                                                   setSelectedSessionTemplates,
                                                   addHeader,
@@ -74,6 +75,7 @@ export default function SessionTemplatesTable({   selectedSessionTemplates,
     const [modalVisible, setModalVisible] = useState<boolean>(false);
     const [deleteSessionTemplateProps, setDeleteSessionTemplateProps] = useState<DeleteSessionTemplateProps>()
     const [resetPaginationKey, setResetPaginationKey] = useState("")
+    const [userIdToLoginUsernameMap, setUserIdToLoginUsernameMap] = useState<UserIdToLoginUsernameMap>(new Map())
     const {push} = useRouter()
     const {addFlashBar} = useFlashBarContext()
     const dataAccessService = new DataAccessService()
@@ -82,6 +84,11 @@ export default function SessionTemplatesTable({   selectedSessionTemplates,
         const r = await dataAccessService.describeSessionTemplates(describeSessionTemplatesRequest)
         return {"objects": r.data.SessionTemplates, "nextToken": r.data.NextToken} as DescribeResponse
     }
+
+    const propertyValueToLabelMaps = new Map<string, ValueToLabelMap>([
+        ["CreatedBy", userIdToLoginUsernameMap],
+        ["LastModifiedBy", userIdToLoginUsernameMap]
+    ])
 
     const filter = <FilterBar
         filteringQuery={query}
@@ -94,7 +101,8 @@ export default function SessionTemplatesTable({   selectedSessionTemplates,
         tokenNameGroupMap={TOKEN_NAME_GROUP_MAP}
         searchTokenToId={SEARCH_TOKEN_TO_ID}
         filteringPlaceholder={FILTER_SESSION_TEMPLATES_CONSTANTS.filteringPlaceholder}
-        dataAccessServiceFunction={describeSessionTemplates}/>
+        dataAccessServiceFunction={describeSessionTemplates}
+        propertyValueToLabelMaps={propertyValueToLabelMaps}/>
 
     const viewUserDetailsButton = () => {
         return <Button variant="normal" disabled={selectedSessionTemplates?.length != 1}
@@ -216,9 +224,11 @@ export default function SessionTemplatesTable({   selectedSessionTemplates,
         }
     }
 
+    const columnDefinitions = getSessionTemplatesTableColumnDefinitions(userIdToLoginUsernameMap)
+
     const table = <Table
         variant={variant}
-        columnDefinitions={SESSION_TEMPLATES_TABLE_COLUMN_DEFINITIONS}
+        columnDefinitions={columnDefinitions}
         columnDisplay={preferences.contentDisplay}
         selectedItems={selectedSessionTemplates as ReadonlyArray<SessionTemplate>}
         onSelectionChange={event => setSelectedSessionTemplates(event.detail.selectedItems)}
@@ -252,7 +262,7 @@ export default function SessionTemplatesTable({   selectedSessionTemplates,
             <TableWithPagination
                 table={table}
                 header={header}
-                defaultSortingColumn={SESSION_TEMPLATES_TABLE_COLUMN_DEFINITIONS[0]}
+                defaultSortingColumn={columnDefinitions[0]}
                 query={query}
                 dataAccessServiceFunction={dataAccessServiceFunction}
                 preferences={preferences}
@@ -262,6 +272,7 @@ export default function SessionTemplatesTable({   selectedSessionTemplates,
                 deleteItemsKey={deleteItemsKey}
                 resetPaginationKey={resetPaginationKey}
                 contentDisplayOptions={CONTENT_DISPLAY_OPTIONS}
+                onUserMapChange={setUserIdToLoginUsernameMap}
             />
             <DeleteSessionTemplateModal visible={modalVisible} setVisible={setModalVisible}
                                         deleteSessionTemplateProps={deleteSessionTemplateProps!}

--- a/dcv-access-console-web-client/server/src/components/session-templates/session-templates-table/SessionTemplatesTableColumnDefinitions.tsx
+++ b/dcv-access-console-web-client/server/src/components/session-templates/session-templates-table/SessionTemplatesTableColumnDefinitions.tsx
@@ -6,14 +6,8 @@ import {SessionTemplate} from "@/generated-src/client";
 import {SESSION_TEMPLATES_TABLE_CONSTANTS} from "@/constants/session-templates-table-constants";
 import OsLabel from "@/components/session-templates/os-label/OsLabel";
 import {capitalizeFirstLetter, formatDate, formatFileSize} from "@/components/common/utils/TextUtils";
-import {UserIdToLoginUsernameMap} from "@/components/session-templates/session-templates-table/SessionTemplatesTable";
 
-const getLoginUsername = (userId: string | undefined, userIdToLoginUsernameMap: UserIdToLoginUsernameMap): string => {
-    if (!userId) return '';
-    return userIdToLoginUsernameMap.get(userId) || userId;
-};
-
-export const getSessionTemplatesTableColumnDefinitions = (userIdToLoginUsernameMap: UserIdToLoginUsernameMap): TableProps.ColumnDefinition<SessionTemplate>[] =>
+export const getSessionTemplatesTableColumnDefinitions = (): TableProps.ColumnDefinition<SessionTemplate>[] =>
     [
         {
             id: SESSION_TEMPLATES_TABLE_CONSTANTS.NAME_ID,
@@ -78,7 +72,7 @@ export const getSessionTemplatesTableColumnDefinitions = (userIdToLoginUsernameM
         {
             id: SESSION_TEMPLATES_TABLE_CONSTANTS.CREATED_BY_ID,
             header: SESSION_TEMPLATES_TABLE_CONSTANTS.CREATED_BY_HEADER,
-            cell: sessionTemplate => getLoginUsername(sessionTemplate.CreatedBy, userIdToLoginUsernameMap),
+            cell: sessionTemplate => sessionTemplate.CreatedBy,
             sortingField: SESSION_TEMPLATES_TABLE_CONSTANTS.CREATED_BY_ID,
         },
         {
@@ -90,7 +84,7 @@ export const getSessionTemplatesTableColumnDefinitions = (userIdToLoginUsernameM
         {
             id: SESSION_TEMPLATES_TABLE_CONSTANTS.LAST_MODIFIED_BY_ID,
             header: SESSION_TEMPLATES_TABLE_CONSTANTS.LAST_MODIFIED_BY_HEADER,
-            cell: sessionTemplate => getLoginUsername(sessionTemplate.LastModifiedBy, userIdToLoginUsernameMap),
+            cell: sessionTemplate => sessionTemplate.LastModifiedBy,
             sortingField: SESSION_TEMPLATES_TABLE_CONSTANTS.LAST_MODIFIED_BY_ID,
         },
         {

--- a/dcv-access-console-web-client/server/src/components/session-templates/session-templates-table/SessionTemplatesTableColumnDefinitions.tsx
+++ b/dcv-access-console-web-client/server/src/components/session-templates/session-templates-table/SessionTemplatesTableColumnDefinitions.tsx
@@ -6,8 +6,14 @@ import {SessionTemplate} from "@/generated-src/client";
 import {SESSION_TEMPLATES_TABLE_CONSTANTS} from "@/constants/session-templates-table-constants";
 import OsLabel from "@/components/session-templates/os-label/OsLabel";
 import {capitalizeFirstLetter, formatDate, formatFileSize} from "@/components/common/utils/TextUtils";
+import {UserIdToLoginUsernameMap} from "@/components/session-templates/session-templates-table/SessionTemplatesTable";
 
-export const SESSION_TEMPLATES_TABLE_COLUMN_DEFINITIONS: TableProps.ColumnDefinition<SessionTemplate>[] =
+const getLoginUsername = (userId: string | undefined, userIdToLoginUsernameMap: UserIdToLoginUsernameMap): string => {
+    if (!userId) return '';
+    return userIdToLoginUsernameMap.get(userId) || userId;
+};
+
+export const getSessionTemplatesTableColumnDefinitions = (userIdToLoginUsernameMap: UserIdToLoginUsernameMap): TableProps.ColumnDefinition<SessionTemplate>[] =>
     [
         {
             id: SESSION_TEMPLATES_TABLE_CONSTANTS.NAME_ID,
@@ -72,7 +78,7 @@ export const SESSION_TEMPLATES_TABLE_COLUMN_DEFINITIONS: TableProps.ColumnDefini
         {
             id: SESSION_TEMPLATES_TABLE_CONSTANTS.CREATED_BY_ID,
             header: SESSION_TEMPLATES_TABLE_CONSTANTS.CREATED_BY_HEADER,
-            cell: sessionTemplate => sessionTemplate.CreatedBy,
+            cell: sessionTemplate => getLoginUsername(sessionTemplate.CreatedBy, userIdToLoginUsernameMap),
             sortingField: SESSION_TEMPLATES_TABLE_CONSTANTS.CREATED_BY_ID,
         },
         {
@@ -84,7 +90,7 @@ export const SESSION_TEMPLATES_TABLE_COLUMN_DEFINITIONS: TableProps.ColumnDefini
         {
             id: SESSION_TEMPLATES_TABLE_CONSTANTS.LAST_MODIFIED_BY_ID,
             header: SESSION_TEMPLATES_TABLE_CONSTANTS.LAST_MODIFIED_BY_HEADER,
-            cell: sessionTemplate => sessionTemplate.LastModifiedBy,
+            cell: sessionTemplate => getLoginUsername(sessionTemplate.LastModifiedBy, userIdToLoginUsernameMap),
             sortingField: SESSION_TEMPLATES_TABLE_CONSTANTS.LAST_MODIFIED_BY_ID,
         },
         {

--- a/dcv-access-console-web-client/server/src/components/session-templates/session-templates-table/SessionTemplatesTableColumnPreferences.tsx
+++ b/dcv-access-console-web-client/server/src/components/session-templates/session-templates-table/SessionTemplatesTableColumnPreferences.tsx
@@ -3,7 +3,7 @@
 
 import {CollectionPreferencesProps} from "@cloudscape-design/components";
 import {SESSION_TEMPLATES_TABLE_CONSTANTS} from "@/constants/session-templates-table-constants";
-import {SESSION_TEMPLATES_TABLE_COLUMN_DEFINITIONS} from "@/components/session-templates/session-templates-table/SessionTemplatesTableColumnDefinitions";
+import {getSessionTemplatesTableColumnDefinitions} from "@/components/session-templates/session-templates-table/SessionTemplatesTableColumnDefinitions";
 
 const DEFAULT_DISPLAY_COLUMNS = [
     SESSION_TEMPLATES_TABLE_CONSTANTS.NAME_ID,
@@ -20,21 +20,24 @@ const CREATE_SESSION_COLUMNS = [
     SESSION_TEMPLATES_TABLE_CONSTANTS.HOST_NUM_OF_CPUS_ID
 ]
 
-export const CONTENT_DISPLAY_OPTIONS: ReadonlyArray<CollectionPreferencesProps.ContentDisplayOption> = SESSION_TEMPLATES_TABLE_COLUMN_DEFINITIONS.map(column => {
+// Use empty map for static column definitions (preferences don't need user mapping)
+const STATIC_COLUMN_DEFINITIONS = getSessionTemplatesTableColumnDefinitions(new Map())
+
+export const CONTENT_DISPLAY_OPTIONS: ReadonlyArray<CollectionPreferencesProps.ContentDisplayOption> = STATIC_COLUMN_DEFINITIONS.map(column => {
     return {
         id: column.id!,
         label: column.header
     }
 })
 
-const DEFAULT_CONTENT_DISPLAY: ReadonlyArray<CollectionPreferencesProps.ContentDisplayItem> = SESSION_TEMPLATES_TABLE_COLUMN_DEFINITIONS.map(column => {
+const DEFAULT_CONTENT_DISPLAY: ReadonlyArray<CollectionPreferencesProps.ContentDisplayItem> = STATIC_COLUMN_DEFINITIONS.map(column => {
     return {
         id: column.id!,
         visible: DEFAULT_DISPLAY_COLUMNS.includes(column.id!)
     }
 })
 
-const CREATE_SESSION_DISPLAY: ReadonlyArray<CollectionPreferencesProps.ContentDisplayItem> = SESSION_TEMPLATES_TABLE_COLUMN_DEFINITIONS.map(column => {
+const CREATE_SESSION_DISPLAY: ReadonlyArray<CollectionPreferencesProps.ContentDisplayItem> = STATIC_COLUMN_DEFINITIONS.map(column => {
     return {
         id: column.id!,
         visible: CREATE_SESSION_COLUMNS.includes(column.id!)

--- a/dcv-access-console-web-client/server/src/components/user-management/user-groups/modify-user-group/edit-user-group-form/EditUserGroupForm.tsx
+++ b/dcv-access-console-web-client/server/src/components/user-management/user-groups/modify-user-group/edit-user-group-form/EditUserGroupForm.tsx
@@ -343,7 +343,7 @@ export default function EditUserGroupForm(
                 Value: filterString
             } as FilterToken],
             SortToken: {
-                Operator: "DESC",
+                Operator: "ASC",
                 Key: "UserId"
             },
             NextToken: nextToken,

--- a/dcv-access-console-web-client/server/src/components/user-management/user-groups/modify-user-group/edit-user-group-form/EditUserGroupForm.tsx
+++ b/dcv-access-console-web-client/server/src/components/user-management/user-groups/modify-user-group/edit-user-group-form/EditUserGroupForm.tsx
@@ -338,7 +338,7 @@ export default function EditUserGroupForm(
 
     const getFilteredUsers = async (filterString: string, nextToken?: string | null) => {
         const describeUsersRequest: DescribeUsersRequestData = {
-            UserIds: [{
+            LoginUsernames: [{
                 Operator: "CONTAINS",
                 Value: filterString
             } as FilterToken],

--- a/dcv-access-console-web-client/server/src/constants/filter-users-bar-constants.ts
+++ b/dcv-access-console-web-client/server/src/constants/filter-users-bar-constants.ts
@@ -4,7 +4,7 @@
 import {FILTER_CONSTANTS} from "@/constants/generic-search-bar-constants";
 
 export const SEARCH_TOKEN_TO_ID: Map<string, string> = new Map<string, string>([
-    ["UserIds", "UserId"],
+    ["UserIds", "LoginUsername"],
     ["DisplayNames", "DisplayName"],
     ["Roles", "Role"],
     ["IsImported", "IsImported"],

--- a/dcv-access-console-web-client/server/src/constants/filter-users-bar-constants.ts
+++ b/dcv-access-console-web-client/server/src/constants/filter-users-bar-constants.ts
@@ -14,7 +14,7 @@ export const SEARCH_TOKEN_TO_ID: Map<string, string> = new Map<string, string>([
 ])
 
 export const TOKEN_NAMES_MAP: Record<string, string> = {
-    "LoginUsernames": "User ID",
+    "LoginUsernames": "User Id",
     "DisplayNames": "User name",
     "Roles": "Role",
     "IsImported": "Imported",
@@ -25,7 +25,7 @@ export const TOKEN_NAMES_MAP: Record<string, string> = {
 }
 
 export const REMOVE_USER_GROUPS_USERS_TOKEN_NAMES_MAP: Record<string, string> = {
-    "LoginUsernames": "User ID",
+    "LoginUsernames": "User Id",
     "DisplayNames": "User name",
     "Roles": "Role",
     "IsImported": "Imported",
@@ -35,7 +35,7 @@ export const REMOVE_USER_GROUPS_USERS_TOKEN_NAMES_MAP: Record<string, string> = 
 }
 
 export const TOKEN_NAME_GROUP_MAP: Record<string, string> = {
-    "LoginUsernames": "User ID values",
+    "LoginUsernames": "User Id values",
     "DisplayNames": "User name values",
     "Roles": "Role values",
     "IsImported": "Imported values",

--- a/dcv-access-console-web-client/server/src/constants/filter-users-bar-constants.ts
+++ b/dcv-access-console-web-client/server/src/constants/filter-users-bar-constants.ts
@@ -4,7 +4,7 @@
 import {FILTER_CONSTANTS} from "@/constants/generic-search-bar-constants";
 
 export const SEARCH_TOKEN_TO_ID: Map<string, string> = new Map<string, string>([
-    ["UserIds", "LoginUsername"],
+    ["LoginUsernames", "LoginUsername"],
     ["DisplayNames", "DisplayName"],
     ["Roles", "Role"],
     ["IsImported", "IsImported"],
@@ -14,7 +14,7 @@ export const SEARCH_TOKEN_TO_ID: Map<string, string> = new Map<string, string>([
 ])
 
 export const TOKEN_NAMES_MAP: Record<string, string> = {
-    "UserIds": "User Id",
+    "LoginUsernames": "User ID",
     "DisplayNames": "User name",
     "Roles": "Role",
     "IsImported": "Imported",
@@ -25,7 +25,7 @@ export const TOKEN_NAMES_MAP: Record<string, string> = {
 }
 
 export const REMOVE_USER_GROUPS_USERS_TOKEN_NAMES_MAP: Record<string, string> = {
-    "UserIds": "User Id",
+    "LoginUsernames": "User ID",
     "DisplayNames": "User name",
     "Roles": "Role",
     "IsImported": "Imported",
@@ -35,7 +35,7 @@ export const REMOVE_USER_GROUPS_USERS_TOKEN_NAMES_MAP: Record<string, string> = 
 }
 
 export const TOKEN_NAME_GROUP_MAP: Record<string, string> = {
-    "UserIds": "User Id values",
+    "LoginUsernames": "User ID values",
     "DisplayNames": "User name values",
     "Roles": "Role values",
     "IsImported": "Imported values",


### PR DESCRIPTION
…erId fallback

**Issue #, if available:**

**Description of changes:**
Added support for filtering and sorting users by loginUsername with fallback to userId when loginUsername is null

Backend changes:
Core filtering and sorting logic:
* Updated Filter.java to implement proper fallback: check loginUsername first, if null check userId 
* Updated Sort.java to sort by loginUsername when sorting by user Id column, falling back to userId when loginUsername is null

Session template filtering:
* Added backend logic to resolve loginUsername to userId specifically for session template filtering operations - when filtering session templates by loginUsername (CreatedBy, LastModifiedBy, UsersSharedWith), the backend now looks up the corresponding userId(s) to perform the actual filter
* Updated API model: Added new filter fields CreatedByLoginUsername, LastModifiedByLoginUsername, and UsersSharedWithLoginUsername to DescribeSessionTemplatesRequestData for loginUsername-based filtering

API model updates:
* Updated API model: Renamed filter parameters in DescribeUsersRequestData for clarity - UserIds for internal userIds, LoginUsernames for loginUsernames
* Added usingExternalAuth flag to DescribeUserInfoResponse - set to true when external authentication is configured (checks for presence of loginUsernameKey, displayNameKey, roleKey, or defaultGroupsKey configuration)

Frontend changes:
Session template filtering and display:
* Updated SessionTemplatesTable to display loginUsername instead of userId for CreatedBy and LastModifiedBy columns
* Updated useSessionTemplatesService to fetch only users from current page templates (CreatedBy/LastModifiedBy) instead of all users, building a userId→loginUsername map for table display and filter dropdowns
* Added propertyValueToLabelMaps to FilterBar for displaying loginUsername in filter dropdowns and token chips (used for CreatedBy, LastModifiedBy, and UsersSharedWith filters)
* Added usingExternalAuth to session and used it to conditionally enable loginUsername-based filtering - when usingExternalAuth is true, user filter keys (CreatedBy, LastModifiedBy, UsersSharedWith) are mapped to their loginUsername equivalents before sending to backend
* Display loginUsername for CreatedBy/LastModifiedBy in session template details page and split panel
*  Display loginUsername instead of userId in create/edit wizard review step for assigned users

Other
* Updated SearchUtils to use loginUsername with userId fallback for Users table filter autocomplete
* Updated user search in AssignUsersGroups.tsx and EditUserGroupForm.tsx to use LoginUsernames filter instead of UserIds
* Updated filter-users-bar-constants.ts to map LoginUsernames instead of UserIds
* Fixed pagination reset on sort column change in TableWithPagination
* Changed default user sort order from DESC to ASC in user selection


**Why is this change necessary:**
Users are more easily identified by their loginUsername than by userId. Previously, the UI displayed loginUsername in tables, but filtering and sorting still operated on userId, creating a mismatch between what users see and what they can filter/sort by. This change aligns the filtering and sorting behavior with the displayed values, improving usability while maintaining backward compatibility with users who only have userId populated.
**How was this change tested:**
- [x] Updated or added new unit tests.
- [ ] Updated or added new integration tests.

**Manual Test Cases - Filter and sorting changes**
**Users Table**
**Users Table - Filter by User ID (shows loginUsername)**
- Action: Click filter dropdown, select "User ID="
- Result: Filter input appears populated with users
<img width="806" height="448" alt="Screenshot 2026-01-13 at 10 43 27 PM" src="https://github.com/user-attachments/assets/7cfd6e83-d094-442d-abab-f3bd1b7ac411" />


---


- Action: Type a loginUsername value (e.g., "ustraria") and select
- Result: Users with matching loginUsername shown
<img width="794" height="293" alt="Screenshot 2026-01-13 at 10 44 32 PM" src="https://github.com/user-attachments/assets/677ad756-9a61-4115-aa4d-b17c39129119" />

---

- Action: Also checked "User Id !=", "User Id:" and "User Id!:" filters
- Result: Filters working and showing correct list of users

---

**Users Table - Sort User ID column**

- Action: Click Users table
- Result: Default sort is on User ID column in ascending order
<img width="817" height="433" alt="Screenshot 2026-01-13 at 11 09 46 PM" src="https://github.com/user-attachments/assets/7736e09e-15d8-4609-ab96-6380f76dbbd6" />

---

- Action: Click "User ID" column header to sort DESC
- Result: Users sorted Z->A
<img width="817" height="452" alt="Screenshot 2026-01-13 at 11 11 18 PM" src="https://github.com/user-attachments/assets/700c86af-8fa5-489f-846e-70fe405e2735" />

---

**Session Templates Table**

- Action: Show "Created by" and "Last modified" by columns
- Result: These columns display the loginUsername instead of userId
<img width="1144" height="445" alt="Screenshot 2026-01-13 at 11 14 36 PM" src="https://github.com/user-attachments/assets/7168083a-358b-4ae4-9435-cac2a12be1a3" />

---

**Session Templates Table - Details panel**
- Action: Select a template 
- Result: Created by" and "Last modified" show loginUsername instead of userId
<img width="335" height="695" alt="Screenshot 2026-01-20 at 2 17 56 AM" src="https://github.com/user-attachments/assets/74c00156-7d78-4c1b-92f2-e2a09ec31c26" />


---

**Session Templates Table - Filter by Created By**

- Action: Click filter dropdown, select "Created By"
- Result: Dropdown shows loginUsername for users from the current page's templates (CreatedBy/LastModifiedBy columns), not all users in the system
<img width="781" height="664" alt="Screenshot 2026-01-16 at 7 40 21 AM" src="https://github.com/user-attachments/assets/31bdd4fd-819b-4947-bbfa-6d46e545ff40" />


---

- Action:  Type a loginUsername value (e.g., "ustraria") and select
- Result: Templates created by ustraria shown 
<img width="889" height="454" alt="Screenshot 2026-01-14 at 11 00 28 AM" src="https://github.com/user-attachments/assets/419e2ee4-d314-4382-b665-ba159b4fc48c" />


---

- Action: Also checked "User Id !=", "User Id:" and "User Id!:" filters
- Result: Filters working and showing correct list of users

---

**Session Templates Table - Filter by Last Modified By**
- Action: Click filter dropdown, select "Last Modified By"
- Result: Dropdown shows loginUsername for users

---

- Action:  Type a loginUsername value (e.g., "admin2@amazon.com") and select
- Result: Templates last modified by admin2@amazon.com shown 
<img width="1232" height="362" alt="Screenshot 2026-01-13 at 11 18 15 PM" src="https://github.com/user-attachments/assets/43c1ff7b-987e-4558-ac8c-37227fd0159a" />

---

- Action: Also checked "User Id !=", "User Id:" and "User Id!:" filters
- Result: Filters working and showing correct list of users

---

**Session Templates Table - Filter by Users Shared With**
- Action:  Type a loginUsername value (e.g., "testuser@company.com") and select
- Result: Templates shared with testuser@company.com shown
<img width="1012" height="310" alt="Screenshot 2026-01-14 at 11 03 11 AM" src="https://github.com/user-attachments/assets/225a5eb9-cf98-42f7-aa02-d6d0032e54e3" />

---

- Action: Also checked "User Id !=" filter
- Result: Filters working and showing correct list of users

---

**Create template and assign user**
- Action: Create a new template and assign users during creation
- Result: Displays login usernames instead of user ids on the review page
<img width="898" height="736" alt="Screenshot 2026-01-20 at 2 17 37 AM" src="https://github.com/user-attachments/assets/6cf80927-ed14-40ec-a8e5-19f5cf89fcea" />



**Assign Session Templates to Users**

- Action: Session Template → select a template → Assign users and groups and type in "Add users" search box
- Result: Users filtered, shows loginUsername as label
<img width="935" height="482" alt="Screenshot 2026-01-13 at 11 24 49 PM" src="https://github.com/user-attachments/assets/56bd7fa9-b429-4561-b012-84ddc03cac18" />

---

**Add Users to User Group**

- Action: User Groups → select a group → Edit and type in "Add users" search box
- Result: Users filtered, shows loginUsername as label
<img width="817" height="556" alt="Screenshot 2026-01-13 at 11 28 19 PM" src="https://github.com/user-attachments/assets/44ea1765-df82-403e-a490-e20127b4cc51" />

---

**Remove Users from User Group**
- Action: User Groups → select a group → Edit and filter by user Id
- Result: Users filtered
<img width="787" height="268" alt="Screenshot 2026-01-13 at 11 29 46 PM" src="https://github.com/user-attachments/assets/166cae89-1b04-4d25-b081-57ec2dd018bd" />

---

**User with no loginUsername**

User `no_login_name` does not have a loginUsername and checked that it was sorted correctly and filterable

---

**Empty filter results**

- Action: Filter by non-existent loginUsername, "user500"
- Resuls: Shows "No users available"

---

**Multiple filters combined**

- Action: Applied multiple filters on Session Templates (CreatedBy + Name)
- Result: Expected templates filtered
<img width="917" height="350" alt="Screenshot 2026-01-13 at 11 32 23 PM" src="https://github.com/user-attachments/assets/27e6520b-065a-4fcb-8d92-eb3d2b8d130a" />

---

Also tested filtering and sorting for internal auth setup

---

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.
 - [ ] Updated the THIRD-PARTY-LICENSES file if applicable.

**Compatibility Checklist:**
- [x] I confirm that the change is backwards compatible.
- [x] There is no modification of dependencies or if there is, a corresponding update to THIRD-PARTY-LICENSES is part of the commit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
