### PR TITLE
fix: Pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -18,7 +18,7 @@ jobs:
     
     steps:
     - name: Check Commit Type
-      uses: gsactions/commit-message-checker@v1
+      uses: gsactions/commit-message-checker@b88ee88552f16f594ca19cb2c7fcd90df95c9bd4 # v1
       with:
         pattern: '^\s*(feat|fix|docs|style|refactor|perf|test|chore)(\(.+?\))?: .{1,50}'
         error: 'Your commit message must have a type (feat|fix|docs|style|refactor|perf|test|chore) and be 50 chars or less.'
@@ -28,7 +28,7 @@ jobs:
         accessToken: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2
       
     - name: Git Secrets scan
       run: |
@@ -39,7 +39,7 @@ jobs:
         git secrets --scan -r
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
       with:
         python-version: 3.11
 
@@ -49,18 +49,18 @@ jobs:
         semgrep --config p/ci --error
 
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@e9fbacdec3bb3b6036605a3e6f7995d66773a8c6 # v3
       with:
         java-version: '17'
         distribution: 'temurin'
 
     - name: Set up Node.js 18
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
       with:
         node-version: '18'
 
     - name: Build dcv-access-console
-      uses: nick-fields/retry@v2
+      uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2
       with:
         timeout_minutes: 10
         max_attempts: 3
@@ -118,7 +118,7 @@ jobs:
         echo "TOX_BRANCH_COVERAGE=$BRANCH_COVERAGE" >> $GITHUB_ENV
 
     - name: Comment PR
-      uses: actions/github-script@v6
+      uses: actions/github-script@00f12e3e20659f42342b1c0226afda7f7c042325 # v6
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |

--- a/.github/workflows/trigger-integ-tests.yaml
+++ b/.github/workflows/trigger-integ-tests.yaml
@@ -15,7 +15,7 @@ jobs:
     
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
         with:
           role-to-assume: ${{secrets.ROLE_ARN}}
           aws-region: ${{secrets.REGION}}


### PR DESCRIPTION
Semgrep's github-actions-mutable-action-tag rule flags mutable version tags as a supply-chain risk (tags can be silently repointed by the action owner). Pins all 8 action references in this repo's 2 workflow files to their current commit SHA, per Semgrep's own remediation guidance and GitHub's recommended Actions hardening practice.
 **Issue #, if available:** Semgrep flagged 8 GitHub Actions references using mutable version tags
  (`@v1`–`@v6`) instead of pinned commit SHAs, via the `github-actions-mutable-action-tag` rule.
  
  **Description of changes:**
  - `.github/workflows/dry-run.yml`: pinned 7 action references (`gsactions/commit-message-checker`,
  `actions/checkout`, `actions/setup-python`, `actions/setup-java`, `actions/setup-node`,
  `nick-fields/retry`, `actions/github-script`) from mutable tags to their current commit SHA, with the
  original version kept as a trailing comment for readability.
  - `.github/workflows/trigger-integ-tests.yaml`: pinned `aws-actions/configure-aws-credentials` the same
  way.
  
  **Why is this change necessary:**
Semgrep scan was failing due to mutable tags.
  Mutable tags (like `@v2`) can be silently repointed by the action's own maintainer to different code — if
  that maintainer's account or repo is ever compromised, every workflow referencing the tag picks up the
  malicious code on its next run, with no visible change on our side. Pinning to a full 40-character commit SHA is Semgrep'sown remediation guidance for this rule, and matches GitHub's recommended Actions hardening practice. Reference: https://sg.run/2LgAL      
  
  **How was this change tested:**
  - [ ] Updated or added new unit tests. n/a
  - [ ] Updated or added new integration tests. n/a
  
  Verified each SHA resolves to the exact commit the original tag currently points to (via the GitHub API),
  and confirmed the resulting YAML structure is unchanged beyond the pinned references (indentation, `with:`
  blocks, and comments all intact).
  
  **Any additional information or context required to review the change:**
  This fix doesn't change any workflow behavior — each action still runs the identical version it did before,
  just referenced by SHA instead of by tag. Only the reference mechanism changed.
  
  **Documentation Checklist:**
  - [ ] Updated the README if applicable. n/a
  - [ ] Updated the THIRD-PARTY-LICENSES file if applicable. n/a
  
  **Compatibility Checklist:**
  - [x] I confirm that the change is backwards compatible.
  - [x] There is no modification of dependencies or if there is, a corresponding update to
  THIRD-PARTY-LICENSES is part of the commit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
